### PR TITLE
update why-checkly menu in the footer

### DIFF
--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -12,6 +12,7 @@
               <a href="/product/synthetic-monitoring/">Synthetic monitoring</a>
             </li>
             <li><a href="/integrations">Integrations</a></li>
+            <li><a href="/why-checkly">Why Checkly</a></li>
             <li><a href="/docs">Docs</a></li>
             <li><a href="/docs/api">API reference</a></li>
             <li><a href="https://changelog.checklyhq.com/" target="_blank" rel="noopener">Changelog</a></li>
@@ -33,7 +34,6 @@
             <li><a href="/security">Security</a></li>
             <li><a href="/terms">Terms of use</a></li>
             <li><a href="/privacy">Privacy policy</a></li>
-            <li><a href="/why-checkly">Why Checkly</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
move `why-checkly` menu from company to product category