### PR TITLE
fix: safelist status badge classes and lint gulp tasks

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -5,7 +5,7 @@ import postcss from 'gulp-postcss'
 import cssImport from 'postcss-import'
 import cssnext from 'postcss-cssnext'
 import purgecss from 'gulp-purgecss'
-import cleanCSS from 'gulp-clean-css';
+import cleanCSS from 'gulp-clean-css'
 import inlineCss from 'gulp-inline-css'
 import sass from 'gulp-sass'
 import revall from 'gulp-rev-all'
@@ -32,30 +32,35 @@ gulp.task('css', function buildCss () {
     .pipe(browserSync.stream())
 })
 
-//purgecss
+// purgecss
 gulp.task('purgecss', () => {
-    return gulp.src('./public/css/**/*.css')
-        .pipe(purgecss({
-            content: ['./public/**/*.html']
-        }))
-        .pipe(gulp.dest('./public/css'))
+  return gulp.src('./public/css/**/*.css')
+    .pipe(purgecss({
+      content: ['./public/**/*.html'],
+      safelist: [/dot--*/]
+    }))
+    .pipe(gulp.dest('./public/css'))
 })
 
-//minifycss
+// minifycss
 gulp.task('minify-css', () => {
   return gulp.src('./public/css/*.css')
     .pipe(cleanCSS({debug: true}, (details) => {
-      console.log(`${details.name}: ${details.stats.originalSize}`);
-      console.log(`${details.name}: ${details.stats.minifiedSize}`);
+      console.log(`${details.name}: ${details.stats.originalSize}`)
+      console.log(`${details.name}: ${details.stats.minifiedSize}`)
     }))
-  .pipe(gulp.dest('./public/css'));
-});
+    .pipe(gulp.dest('./public/css'))
+})
 
 // Compile Javascript
 gulp.task('js', (cb) => {
   const myConfig = Object.assign({}, webpackConfig)
 
-  webpack(myConfig, (err, stats) => {
+  webpack(myConfig, (err) => {
+    if (err) {
+      throw err
+    }
+
     browserSync.reload()
     cb()
   })
@@ -118,7 +123,7 @@ gulp.task('watch', () => {
 })
 
 // Development server with browsersync
-gulp.task('server', gulp.series(['hugo', 'css', 'js', 'fonts', 'purgecss', 'minify-css','serve', 'watch']))
+gulp.task('server', gulp.series(['hugo', 'css', 'js', 'fonts', 'purgecss', 'minify-css', 'serve', 'watch']))
 
 gulp.task('clean', () => {
   return del(['./public/**/*'])
@@ -142,7 +147,7 @@ function buildSite (cb, options, environment = 'development') {
       cb()
     } else {
       browserSync.notify('Hugo build failed :(')
-      cb('Hugo build failed')
+      cb(new Error('Hugo build failed'))
     }
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5945,6 +5945,80 @@
         }
       }
     },
+    "gulp-cli": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.3.0.tgz",
+      "integrity": "sha512-zzGBl5fHo0EKSXsHzjspp3y5CONegCm8ErO5Qh0UzFzk2y4tMvzLWhoDokADbarfZRL2pGpRp7yt6gfJX4ph7A==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^1.0.1",
+        "archy": "^1.0.0",
+        "array-sort": "^1.0.0",
+        "color-support": "^1.1.3",
+        "concat-stream": "^1.6.0",
+        "copy-props": "^2.0.1",
+        "fancy-log": "^1.3.2",
+        "gulplog": "^1.0.0",
+        "interpret": "^1.4.0",
+        "isobject": "^3.0.1",
+        "liftoff": "^3.1.0",
+        "matchdep": "^2.0.0",
+        "mute-stdout": "^1.0.0",
+        "pretty-hrtime": "^1.0.0",
+        "replace-homedir": "^1.0.0",
+        "semver-greatest-satisfied-range": "^1.1.0",
+        "v8flags": "^3.2.0",
+        "yargs": "^7.1.0"
+      },
+      "dependencies": {
+        "interpret": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+          "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+          "dev": true
+        },
+        "v8flags": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
+          "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
+          "dev": true,
+          "requires": {
+            "homedir-polyfill": "^1.0.1"
+          }
+        },
+        "yargs": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.1.tgz",
+          "integrity": "sha512-huO4Fr1f9PmiJJdll5kwoS2e4GqzGSsMT3PPMpOwoVkOK8ckqAewMTZyA6LXVQWflleb/Z8oPBEvNsMft0XE+g==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "5.0.0-security.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "5.0.0-security.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0-security.0.tgz",
+          "integrity": "sha512-T69y4Ps64LNesYxeYGYPvfoMTt/7y1XtfpIslUeK4um+9Hu7hlGoRtaDLvdXb7+/tfq4opVa2HRY5xGip022rQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0",
+            "object.assign": "^4.1.0"
+          }
+        }
+      }
+    },
     "gulp-flatten": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/gulp-flatten/-/gulp-flatten-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-promise": "^3.8.0",
     "eslint-plugin-standard": "^3.1.0",
+    "gulp-cli": "^2.3.0",
     "s3-deploy": "^1.4.0",
     "serve": "^11.3.2",
     "shins": "^2.4.1-0",

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -18,7 +18,7 @@
             <li><a href="/docs/api">API reference</a></li>
             <li><a href="https://changelog.checklyhq.com/" target="_blank" rel="noopener">Changelog</a></li>
             <li><a href="/pricing">Pricing</a></li>
-            <li><a href="https://is.checkly.online">Status</a><span id="footer-status-indicator" class=""></span></li>
+            <li><a href="https://is.checkly.online">Status</a><span id="footer-status-indicator" class="dot"></span></li>
           </ul>
         </div>
       </div>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -287,13 +287,13 @@ $(document).ready(() => {
     })
     .then(function (res) {
       if (res.status.indicator === 'none') {
-        $('#footer-status-indicator').addClass('dot dot--green')
+        $('#footer-status-indicator').addClass('dot--green')
       }
       if (res.status.indicator === 'minor') {
-        $('#footer-status-indicator').addClass('dot dot--yellow')
+        $('#footer-status-indicator').addClass('dot--yellow')
       }
       if (res.status.indicator === 'major' || res.status.indicator === 'critical') {
-        $('#footer-status-indicator').addClass('dot dot--red')
+        $('#footer-status-indicator').addClass('dot--red')
       }
     })
 })

--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -56,28 +56,7 @@ p {
   }
 }
 
-.dot {
-  height: 8px;
-  width: 8px;
-  border-radius: 50%;
-  display: inline-block;
-  margin-left: .4rem;
-  vertical-align: middle;
-  position: relative;
-  margin-top: -2px;
-}
-
-.dot--green {
-  background-color: $green;
-}
-.dot--yellow {
-  background-color: $yellow;
-}
-.dot--red {
-  background-color: $red;
-}
 // Forms
-
 .form-header {
   font-size: 1.25rem;
   font-weight: 400;
@@ -97,7 +76,6 @@ p {
 
 
 // Image & Video
-
 .screen-video {
   background-color: $white;
   border-radius: 4px;
@@ -144,7 +122,6 @@ img.avatar {
 
 
 // alignment
-
 .text-side {
   margin-top: 50px;
 

--- a/src/scss/_footer.scss
+++ b/src/scss/_footer.scss
@@ -65,6 +65,27 @@
   .desktop-show {
     display: block;
   }
+
+  .dot {
+    height: 8px;
+    width: 8px;
+    border-radius: 50%;
+    display: inline-block;
+    margin-left: .4rem;
+    vertical-align: middle;
+    position: relative;
+    margin-top: -2px;
+
+    &--green {
+      background-color: $green;
+    }
+    &--yellow {
+      background-color: $yellow;
+    }
+    &--red {
+      background-color: $red;
+    }
+  }
 }
 
 @include media-breakpoint-down(md) {


### PR DESCRIPTION
It was a purge issue. As `dot--` classes were loaded dynamically, purgeCSS was removing them on build time.

- Added `dot--` to safe list
- Move styles to footer scss
- Lint gulp tasks
