### PR TITLE
refactor: external links open in new tab

### DIFF
--- a/site/content/guides/api-monitoring.md
+++ b/site/content/guides/api-monitoring.md
@@ -10,9 +10,9 @@ avatar: 'images/avatars/giovanni-rago.png'
 
 ## APIs and the JAMStack
 
-With the rise of the [JAMStack](https://jamstack.org/), the already broadly used web APIs have been brought further into the spotlight and explicitly named as cornerstone of a new way of building web applications. In the JAMStack paradigm, applications rely on APIs (the _A_ in "JAM") returning structured data (JSON or XML) when queried via the HTML and Javascript-based frontend. 
+With the rise of the {{< newtabref  href="https://jamstack.org/" title="JAMStack" >}}, the already broadly used web APIs have been brought further into the spotlight and explicitly named as cornerstone of a new way of building web applications. In the JAMStack paradigm, applications rely on APIs (the _A_ in "JAM") returning structured data (JSON or XML) when queried via the HTML and Javascript-based frontend. 
 
-The API calls might be aimed at internal services or at third-parties handling complex flows such as content management, authentication, merchant services and more. An example of third-party API could be [Stripe](https://stripe.com/), which acts as payment infrastructure for a multitude of businesses.
+The API calls might be aimed at internal services or at third-parties handling complex flows such as content management, authentication, merchant services and more. An example of third-party API could be {{< newtabref  href="https://stripe.com/" title="Stripe" >}}, which acts as payment infrastructure for a multitude of businesses.
 
 Given their importance in this new kind of web application, APIs both internal and external need to be tightly monitored, as failures and performance degradations will immediately be felt by the end-user.
 
@@ -44,15 +44,15 @@ Let's dive in deeper into each point.
 
 There is a large variety of valid requests that a user might make to a given endpoint. Being able to customise all aspects of our test request is therefore fundamental. Key aspects are:
 
-1. [Method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods), like `GET`, `PUT`, `POST`, `DELETE`, etc
-2. [Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers), like `Accept`, `Authorization`, `Content-Type`, `Cookie`, `User-Agent`, etc
-3. [Query parameters](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web#query)
+1. {{< newtabref  href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods" title="Methods" >}}[Method](), like `GET`, `PUT`, `POST`, `DELETE`, etc
+2. {{< newtabref  href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers" title="Headers" >}}[Headers](), like `Accept`, `Authorization`, `Content-Type`, `Cookie`, `User-Agent`, etc
+3. {{< newtabref  href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web#query" title="Query parameters" >}}
 
 {{< figure src="/guides/images/guides-checkly-swagger.png" alt="swagger api documentation" title="Swagger is a popular tool for generating API documentation" >}}
 
 Essentially, we are trying to craft a complete request for exact endpoint. Not only that, but we might want to have multiple requests set up to cover specific options or negative cases, too.
 
-One such case can be where user-specified parameters such as pagination and timeframes might largely change the response. This is exemplified by the `List Customers` method in [Stripe's Customer API](https://stripe.com/docs/api/customers/list?lang=curl), which we can use to query elements in very different ways, such as by just specifying a limit of results or asking for all results linked to a specific creation date. In this case, both of the following cases are worth monitoring:
+One such case can be where user-specified parameters such as pagination and timeframes might largely change the response. This is exemplified by the `List Customers` method in {{< newtabref  href="https://stripe.com/docs/api/customers/list?lang=curl" title="Stripe's Customer API" >}}, which we can use to query elements in very different ways, such as by just specifying a limit of results or asking for all results linked to a specific creation date. In this case, both of the following cases are worth monitoring:
 
 ```sh
 curl https://api.stripe.com/v1/customers \
@@ -68,7 +68,7 @@ curl https://api.stripe.com/v1/customers \
   -G
 ```
 
-If we chose to set up a call using Javascript, for example, we could achieve the same call as in the first case above using [axios](https://github.com/axios/axios):
+If we chose to set up a call using Javascript, for example, we could achieve the same call as in the first case above using {{< newtabref  href="https://github.com/axios/axios" title="axios" >}}:
 
 ```js
 const { default: axios } = require("axios");
@@ -95,7 +95,7 @@ To validate the API response, we should be able to check against
 2. Headers
 3. Body
 
-Let's look at an example: creating a customer via the [Stripe Customer API](https://stripe.com/docs/api/customers/create?lang=curl). Since we are not the API's developers, we are assuming the result we get running call right now is correct and can be used to model our assertions. Let's run the following curl command in verbose mode:
+Let's look at an example: creating a customer via the {{< newtabref  href="https://stripe.com/docs/api/customers/create?lang=curl" title="Stripe Customer API" >}}. Since we are not the API's developers, we are assuming the result we get running call right now is correct and can be used to model our assertions. Let's run the following curl command in verbose mode:
 
 ```sh
 curl -v https://api.stripe.com/v1/customers \
@@ -141,7 +141,7 @@ And finally the response body, which we might want to inspect to ensure the righ
   [clipped]
 ```
 
-We could expand on our previous code example by add adding an assertion library, such as [chai's](https://www.chaijs.com/api/assert/) or [Jest expect](https://jestjs.io/docs/expect):
+We could expand on our previous code example by add adding an assertion library, such as {{< newtabref  href="https://www.chaijs.com/api/assert/" title="chai's" >}} or {{< newtabref  href="https://jestjs.io/docs/expect" title="Jest expect" >}}:
 
 ```js
 const { default: axios } = require("axios");

--- a/site/content/guides/end-to-end-monitoring.md
+++ b/site/content/guides/end-to-end-monitoring.md
@@ -8,7 +8,7 @@ avatar: 'images/avatars/giovanni-rago.png'
 
 ## Headless browser testing
 
-Over the course of the last decade, especially thanks to tools such as [Selenium](https://www.selenium.dev/) and (more recently) [Cypress](https://www.cypress.io/), **automated End-to-End testing (E2E testing) has become widespread across industries**. 
+Over the course of the last decade, especially thanks to tools such as {{< newtabref  href="https://www.selenium.dev/" title="Selenium" >}} and (more recently) {{< newtabref  href="https://www.cypress.io/" title="Cypress" >}}, **automated End-to-End testing (E2E testing) has become widespread across industries**. 
 
 Broadly speaking, **E2E testing entails running fully automated test suites with the goal of catching bugs before they hit production** and, therefore, negatively affect the user experience. These test suites need to be carefully scripted using dedicated tools, as well as to be made stable and fast enough to test the most important end-user flows on every build, PR or commit, depending on the application under test and the organisation's automation maturity.
 
@@ -20,7 +20,7 @@ The industry has learned to struggle with the challenges this approach presents:
 
 **All of the above lead to higher costs and slower delivery.**
 
-The appearance of mature **headless browser automation tools, such as [Puppeteer](https://pptr.dev) and [Playwright](https://playwright.dev), offers a response** to many of the above issues by allowing testing in the browser without its GUI, which yields higher speed and stability coupled with lower resource consumption.
+The appearance of mature **headless browser automation tools, such as {{< newtabref  href="https://pptr.dev" title="Puppeteer" >}} and {{< newtabref  href="https://playwright.dev" title="Playwright" >}}, offers a response** to many of the above issues by allowing testing in the browser without its GUI, which yields higher speed and stability coupled with lower resource consumption.
 
 ## E2E monitoring (AKA synthetic monitoring)
 
@@ -37,7 +37,7 @@ A few key flows for an e-commerce websites could be:
 2. Finding a product through search
 3. Adding products to the basket and checking out
 
-Let's see how to set them up - for this example, we will do that on our [demo web shop](https://danube-webshop.herokuapp.com).
+Let's see how to set them up - for this example, we will do that on our {{< newtabref  href="https://danube-webshop.herokuapp.com" title="demo web shop" >}}.
 
 {{< figure src="/guides/images/guides-danube.png" alt="demo website screenshot" title="Our demo website" >}}
 
@@ -176,7 +176,7 @@ const { chromium } = require("playwright");
 {{< /tab >}}
 {{< /tabs >}}
 
-These can be run on our own machine without issues with [very little preparation](https://playwright.dev/docs/intro) with a simple `node script.js`.
+These can be run on our own machine without issues with {{< newtabref  href="https://playwright.dev/docs/intro" title="very little preparation" >}} with a simple `node script.js`.
 
 ## Monitoring application performance
 
@@ -242,7 +242,7 @@ const assert = require("chai").assert;
 {{< /tab >}}
 {{< /tabs >}}
 
-We can also use Web Performance APIs such as [Navigation Timing](https://www.w3.org/TR/navigation-timing/) and [Resource Timing](https://www.w3.org/TR/resource-timing-1/), as well as libraries such as Google Lighthouse. For more examples, see our [dedicated performance guide](https://www.checklyhq.com/learn/headless/basics-performance/).
+We can also use Web Performance APIs such as {{< newtabref  href="https://www.w3.org/TR/navigation-timing" title="Navigation Timing" >}} and {{< newtabref  href="https://www.w3.org/TR/resource-timing-1" title="Resource Timing" >}}, as well as libraries such as Google Lighthouse. For more examples, see our [dedicated performance guide](https://www.checklyhq.com/learn/headless/basics-performance/).
 
 ## End to end application monitoring
 
@@ -268,7 +268,7 @@ Tests can be kicked off of CI pipelines. You might want to use different hooks (
 
 ## Develop-preview-test
 
-If you are using provider like Vercel, you can automatically trigger your checks to run on deployed PRs, too, to reap the benefits of the [develop-preview-test approach](https://rauchg.com/2020/develop-preview-test).
+If you are using provider like Vercel, you can automatically trigger your checks to run on deployed PRs, too, to reap the benefits of the {{< newtabref  href="https://rauchg.com/2020/develop-preview-test" title="develop-preview-test approach" >}}.
 
 ## Pitfalls
 

--- a/site/content/guides/monitoring-as-code.md
+++ b/site/content/guides/monitoring-as-code.md
@@ -10,11 +10,11 @@ avatar: 'images/avatars/giovanni-rago.png'
 
 Historically, IT infrastructure has been provisioned manually, both on premise and in the cloud. This presented several challenges, including fragmented workflows, lack of transparency and scalability issues. In response to these problems, the last few years have seen a shift to the Infrastructure-as-Code (IaC) paradigm, in which large-scale systems are declared in configuration files as code.
 
-A new generation of tools has emerged to serve this use case, the most notable example of which is [HashiCorp Terraform](https://www.terraform.io/). Terraform provides a CLI workflow allowing users to specify what the final infrastructure setup should look like, and then takes care of all the intermediate steps needed to get there.
+A new generation of tools has emerged to serve this use case, the most notable example of which is {{< newtabref  href="https://www.terraform.io/" title="HashiCorp Terraform" >}}. Terraform provides a CLI workflow allowing users to specify what the final infrastructure setup should look like, and then takes care of all the intermediate steps needed to get there.
 
 {{< figure src="/guides/images/guides-terraform-aws.png" alt="provisioning aws infrastructure - code snippet" title="Provisioning AWS infrastructure via Terraform" >}}
 
-Terraform can be used to provision infrastructure on many different cloud vendors thanks to its provider ecosystem: each provider maps to the vendor's API, exposing different resources in a domain-specific language known as [HCL](https://www.terraform.io/docs/language/syntax/configuration.html).
+Terraform can be used to provision infrastructure on many different cloud vendors thanks to its provider ecosystem: each provider maps to the vendor's API, exposing different resources in a domain-specific language known as {{< newtabref  href="https://www.terraform.io/docs/language/syntax/configuration.html" title="HCL" >}}.
 
 ## Monitoring the IaC way
 
@@ -34,17 +34,17 @@ What does one gain when moving from a manual to a Monitoring-as-Code approach? T
 
 Users who have just started out will be familiar with creating checks, groups, alert channels and other resources through the Checkly UI. The official Terraform provider enables them to instead declare exactly what their active monitoring setup should look like, and have it provisioned by Terraform in just a few seconds - regardless of whether that means creating tens, hundreds or thousands of resources.
 
-You can [find the Checkly Terraform provider](https://registry.terraform.io/providers/checkly/checkly/latest) on the official Terraform registry.
+You can {{< newtabref  href="https://registry.terraform.io/providers/checkly/checkly/latest" title="find the Checkly Terraform provider" >}} on the official Terraform registry.
 
 {{< figure src="/guides/images/guides-provider.png" alt="official Checkly Terraform provider on Terraform Registry" title="Official Checkly Terraform provider" >}}
 
 ## Monitoring an e-commerce website - as code
 
-How does this all look like in practice? Let's find out by creating a small monitoring setup for our [demo e-commerce website](https://danube-webshop.herokuapp.com).
+How does this all look like in practice? Let's find out by creating a small monitoring setup for our {{< newtabref  href="https://danube-webshop.herokuapp.com" title="demo e-commerce website" >}}.
 
 ### Setting up our Terraform project
 
-For our example we will be creating browser checks using [Playwright](https://playwright.dev) scripts we have previously written as part of our Playwright guides.
+For our example we will be creating browser checks using {{< newtabref  href="https://playwright.dev" title="Playwright" >}} scripts we have previously written as part of our Playwright guides.
 
 {{< tabs "Web shop example" >}}
 {{< tab "Login" >}}
@@ -464,7 +464,7 @@ Going through the usual `terraform plan` and `terraform apply` sequence will app
 
 We are now fully up and running with our monitoring-as-code setup. Our checks will run on a schedule, informing us promptly if anything were to go wrong. Rapidly getting to know about failures in our API and key website flows will allow us to react fast and mitigate impact on our users, ensuring a better experience with our product.
 
-You can find the complete setup described in this guide on our [dedicated repository](https://github.com/checkly/guides-monitoring-as-code).
+You can find the complete setup described in this guide on our {{< newtabref  href="https://github.com/checkly/guides-monitoring-as-code" title="dedicated repository" >}}.
 
 ### Expanding our setup
 
@@ -473,4 +473,4 @@ As our setup expands, we might want to deploy additional tools to make our lives
 1. Iterate over existing Playwright scripts and [create multiple checks while declaring only one resource](https://blog.checklyhq.com/scaling-puppeteer-playwright-on-checkly-with-terraform#iterating-through-scripts-for-shorter-config).
 2. [Group checks together](https://blog.checklyhq.com/scaling-puppeteer-playwright-on-checkly-with-terraform#grouping-checks-together) to better handle them in large numbers.
 3. [Use code snippets](https://blog.checklyhq.com/scaling-puppeteer-playwright-on-checkly-with-terraform#reducing-code-duplication-with-snippets) to avoid code duplication and reduce maintenance.
-4. Move your workflow to [Terraform Cloud](https://www.terraform.io/cloud) to easily collaborate with your team when managing your Monitoring-as-Code configuration.
+4. Move your workflow to {{< newtabref  href="https://www.terraform.io/cloud" title="Terraform Cloud" >}} to easily collaborate with your team when managing your Monitoring-as-Code configuration.

--- a/site/content/guides/openapi-swagger.md
+++ b/site/content/guides/openapi-swagger.md
@@ -8,7 +8,7 @@ avatar: 'images/avatars/giovanni-rago.png'
 
 ## The OpenAPI Specification
 
-The <a href="https://spec.openapis.org/oas/v3.1.0" target=_blank>OpenAPI Specification (OAS)</a> specifies a standard, language-agnostic and machine-readable format to describe a web API in one or more files. Nowadays, it acts as a vendor-neutral standard for describing the structure and behaviour of HTTP-based APIs, and exists as part of the <a href="https://www.openapis.org/" target=_blank>OpenAPI Initiative (OAI)</a>.
+The {{< newtabref  href="https://spec.openapis.org/oas/v3.1.0" title="OpenAPI Specification (OAS)" >}} specifies a standard, language-agnostic and machine-readable format to describe a web API in one or more files. Nowadays, it acts as a vendor-neutral standard for describing the structure and behaviour of HTTP-based APIs, and exists as part of the {{< newtabref  href="https://www.openapis.org/" title="OpenAPI Initiative (OAI)" >}}.
 
 Following the OAS brings the following advantages:
 
@@ -16,13 +16,13 @@ Following the OAS brings the following advantages:
 2. The possibility of automatically generating documentation, implementation logic and even mock servers for testing.
 3. Early validation of the data flows happening within the API.
 
-For those new to the OAS and wanting to get a basic understanding without diving straight into the specification itself, the official <a href="https://oai.github.io/Documentation/specification.html" target=_blank>OpenAPI Specification Explained</a> guide is a great place to start.
+For those new to the OAS and wanting to get a basic understanding without diving straight into the specification itself, the official {{< newtabref  href="https://oai.github.io/Documentation/specification.html" title="OpenAPI Specification Explained" >}} guide is a great place to start.
 
 ## Swagger vs OpenAPI
 
-The OpenAPI Specification is based on the <a href="https://swagger.io/specification/v2/" target=_blank>Swagger Specification</a>, which had previously been a project driven by <a href="https://smartbear.com/" target=_blank>SmartBear Software</a>. SmartBear donated the Swagger Specification to the Linux Foundation in 2015. In a sense, the OAS is the newer, fully open source-driven incarnation of the Swagger Specification.
+The OpenAPI Specification is based on the SmartBear SoftwareSmartBear Software, which had previously been a project driven by {{< newtabref  href="https://smartbear.com" title="SmartBear Software" >}}. SmartBear donated the Swagger Specification to the Linux Foundation in 2015. In a sense, the OAS is the newer, fully open source-driven incarnation of the Swagger Specification.
 
-The name <a href="https://swagger.io/" target=_blank>Swagger</a> today indicates a set of tools, both free and paid, that support users of the OpenAPI ecosystem.
+The name {{< newtabref  href="https://swagger.io/" title="Swagger" >}} today indicates a set of tools, both free and paid, that support users of the OpenAPI ecosystem.
 
 ## Exploring the specification
 
@@ -84,7 +84,7 @@ paths:
                 $ref: "#/components/schemas/balance"
 ```
 
-Notice we are explicitly defining which schemas the parameter and response should conform to. In the case of our response, we are referring to an <a href="https://swagger.io/docs/specification/using-ref" target=_blank>externally defined schema</a>. This is helpful when we need to reuse a schema definition multiple times across our spec file.
+Notice we are explicitly defining which schemas the parameter and response should conform to. In the case of our response, we are referring to an {{< newtabref  href="https://swagger.io/docs/specification/using-ref" title="externally defined schema" >}}. This is helpful when we need to reuse a schema definition multiple times across our spec file.
 
 As we proceed, we might add multiple endpoints, each with one or more operations.
 
@@ -114,13 +114,13 @@ We can keep on building out our API spec as needed. The more precisely we descri
 
 ## Generating documentation from OpenAPI
 
-Let's now take a look at a more complex, finished example: the <a href="https://petstore.swagger.io/v2/swagger.json" target=_blank>Swagger PetStore demo</a>. Even if we had written it ourselves, this description of a complete API could be overwhelming if we just tried to parse the file line by line. To first-time users, that could feel even more daunting. A better option would be to use the open-source toolset Swagger offers to generate human-readable, interactive API documentation from the file we already have.
+Let's now take a look at a more complex, finished example: the {{< newtabref  href="https://petstore.swagger.io/v2/swagger.json" title="Swagger PetStore demo" >}}. Even if we had written it ourselves, this description of a complete API could be overwhelming if we just tried to parse the file line by line. To first-time users, that could feel even more daunting. A better option would be to use the open-source toolset Swagger offers to generate human-readable, interactive API documentation from the file we already have.
 
-Pasting the content of the spec file to <a href="https://editor.swagger.io" target=_blank>Swagger Editor</a> will produce a preview of our <a href="https://swagger.io/tools/swagger-ui/" target=_blank>Swagger UI documentation</a>. This is helpful for consumers of the API, who will be presented with an orderly documentation page breaking down each endpoint while also allowing users to test out different operations. 
+Pasting the content of the spec file to {{< newtabref  href="https://editor.swagger.io" title="Swagger Editor" >}} will produce a preview of our {{< newtabref  href="https://swagger.io/tools/swagger-ui/" title="Swagger UI documentation" >}}. This is helpful for consumers of the API, who will be presented with an orderly documentation page breaking down each endpoint while also allowing users to test out different operations. 
 
 ## Generating boilerplate code from OpenAPI
 
-When writing a new API, we will oftentimes need to produce a certain amount of boilerplate code for both our provider (e.g. a server exposing our API for consumption) and consumer (e.g. an SDK for our API) applications. Once we have our OpenAPI file in place, we can use <a href="https://swagger.io/tools/swagger-codegen" target=_blank>Swagger Codegen</a> (also available within Swagger Editor) to automatically generate that code for us, saving us precious time and reducing the avenues for human error.
+When writing a new API, we will oftentimes need to produce a certain amount of boilerplate code for both our provider (e.g. a server exposing our API for consumption) and consumer (e.g. an SDK for our API) applications. Once we have our OpenAPI file in place, we can use {{< newtabref  href="https://swagger.io/tools/swagger-codegen title="Swagger Codegen" >}} (also available within Swagger Editor) to automatically generate that code for us, saving us precious time and reducing the avenues for human error.
 
 The following snippet is an example of the code Swagger Codegen can generate starting from an OAS file.
 
@@ -183,11 +183,11 @@ The following snippet is an example of the code Swagger Codegen can generate sta
 
 ```
 
-Depending on how much is described in a given API spec, it is possible to move even further and generate tests, mock servers and more. See <a href="https://openapi.tools" target=_blank>openapi.tools</a> for an up-to-date list of tools belonging to the OpenAPI ecosystem.
+Depending on how much is described in a given API spec, it is possible to move even further and generate tests, mock servers and more. See {{< newtabref  href="https://openapi.tools" title="openapi.tools" >}} for an up-to-date list of tools belonging to the OpenAPI ecosystem.
 
 ## Generated monitoring checks with Checkly
 
-API monitoring is key to ensure that our endpoints are returning the correct results in an acceptable timeframe.  If we can generate APIs from a OAS description file, we can also generate monitoring checks for them. Checkly is [a member of the OpenAPI initiative](https://www.openapis.org/membership/members), and allows us to import an OpenAPI spec file and automatically creates one or more checks depending on the amount of information available. All it takes is a couple of clicks.
+API monitoring is key to ensure that our endpoints are returning the correct results in an acceptable timeframe.  If we can generate APIs from a OAS description file, we can also generate monitoring checks for them. Checkly is {{< newtabref  href="https://www.openapis.org/membership/members" title="a member of the OpenAPI initiative" >}}, and allows us to import an OpenAPI spec file and automatically creates one or more checks depending on the amount of information available. All it takes is a couple of clicks.
 
 When creating an API check, select the `import from Swagger / OpenAPI` button.
 

--- a/site/content/guides/openapi-swagger.md
+++ b/site/content/guides/openapi-swagger.md
@@ -120,7 +120,7 @@ Pasting the content of the spec file to {{< newtabref  href="https://editor.swag
 
 ## Generating boilerplate code from OpenAPI
 
-When writing a new API, we will oftentimes need to produce a certain amount of boilerplate code for both our provider (e.g. a server exposing our API for consumption) and consumer (e.g. an SDK for our API) applications. Once we have our OpenAPI file in place, we can use {{< newtabref  href="https://swagger.io/tools/swagger-codegen title="Swagger Codegen" >}} (also available within Swagger Editor) to automatically generate that code for us, saving us precious time and reducing the avenues for human error.
+When writing a new API, we will oftentimes need to produce a certain amount of boilerplate code for both our provider (e.g. a server exposing our API for consumption) and consumer (e.g. an SDK for our API) applications. Once we have our OpenAPI file in place, we can use {{< newtabref  href="https://swagger.io/tools/swagger-codegen" title="Swagger Codegen" >}} (also available within Swagger Editor) to automatically generate that code for us, saving us precious time and reducing the avenues for human error.
 
 The following snippet is an example of the code Swagger Codegen can generate starting from an OAS file.
 

--- a/site/layouts/shortcodes/newtabref.html
+++ b/site/layouts/shortcodes/newtabref.html
@@ -1,0 +1,1 @@
+<a href="{{ .Get "href" }}" rel="noopener" target="_blank">{{ .Get "title" }}</a>


### PR DESCRIPTION
@hlenke here is the PR mentioned in https://github.com/checkly/checklyhq.com/pull/6
Now all external links within Guides open in a new tab.