### PR TITLE
feat: updates pricing page: features + calc

### DIFF
--- a/site/layouts/pricing/list.html
+++ b/site/layouts/pricing/list.html
@@ -158,10 +158,10 @@
         <h4 class="mb-5">
           5 API checks <span class="text-muted">running every</span> minute <span class="text-muted">makes </span> <span class="pricing__check-runs-indicator">223,200</span> <span class="text-muted"> check runs per month</span>
         </h4>
-        <div class="d-flex flex-column text-left">
-          <div class="text-muted mb-2">Daily runs: 24 x 60 = 1440 runs</div>
-          <div class="text-muted mb-2">Monthly runs: 1440 x 31 = 44,640 runs</div>
-          <div class="text-muted">Five checks: 5 x 44,640 = <span class="text-gray-dark pricing__check-runs-indicator pricing__check-runs-indicator--secondary">223,200 runs</span></div>
+        <div class="d-flex flex-column text-center">
+          <div class="text-muted mb-2">Daily runs: 5 x 24 x 60 = 7,200 runs</div>
+          <div class="text-muted mb-2">Monthly runs: 7200 x 31 = <span class="text-gray-dark pricing__check-runs-indicator pricing__check-runs-indicator--secondary">223,200 runs</span> </div>
+          <div class="text-muted">Which costs me (223,200 / 10,000) * $1.20 = $26.80 per month on the "Pay as you go"-plan.</div>
         </div>
         <div class="pricing__spreadsheet">
           <a class="d-flex" href="https://docs.google.com/spreadsheets/d/1ahnSqIDp6VXNSGWqSOtm2lSSo5ylIaeuZn57qNPM0H0/copy" target="_blank" rel="noopener">
@@ -328,7 +328,15 @@
             <td><i class="ion-ios-checkmark text-success"></i></td>
           </tr>
           <tr>
-            <th>Email, Slack & Webhooks</th>
+            <th>
+              <div class="pricing__tooltip">
+                Email, Slack, Webhooks and more
+                <div class="pricing__tooltip--body">
+                  All plans have access to our basic alerting integrations like email, Slack and Webhooks. In addition,
+                  you also have access to an ever growing list of 3rd party integrations like Pagerduty, Opsgenie and Discord.
+                </div>
+              </div>
+            </th>
             <td><i class="ion-ios-checkmark text-success"></i></td>
             <td><i class="ion-ios-checkmark text-success"></i></td>
             <td><i class="ion-ios-checkmark text-success"></i></td>
@@ -380,31 +388,13 @@
           <tr>
             <th>
               <div class="pricing__tooltip">
-                GitHub triggers
+                CI/CD & Deployment triggers
                 <div class="pricing__tooltip--body">
-                  Automatically trigger checks from GitHub PR or commits. Works out-of-the-box with Vercel, Heroku etc.
+                  Automatically trigger checks from a GitHub PR or commit for automated testing before deploying to production. Works out-of-the-box with Vercel, Heroku etc. Use our command line triggers to integrate with any CI/CD provider.
                 </div>
               </div>
             </th>
             <td><i class="ion-ios-checkmark text-success"></i></td>
-            <td><i class="ion-ios-checkmark text-success"></i></td>
-            <td><i class="ion-ios-checkmark text-success"></i></td>
-          </tr>
-          <tr>
-            <th>
-              <div class="pricing__tooltip">
-                CI/CD custom triggers
-                <div class="pricing__tooltip--body">
-                  Trigger a check run from the terminal or your CI/CD pipeline for automated testing before or after building and deploying. Works with any CI/CD provider.                </div>
-              </div>
-            </th>
-            <td><i class="ion-close-circled text-muted"></i></td>
-            <td><i class="ion-ios-checkmark text-success"></i></td>
-            <td><i class="ion-ios-checkmark text-success"></i></td>
-          </tr>
-          <tr>
-            <th>Pagerduty & Opsgenie</th>
-            <td><i class="ion-close-circled text-muted"></i></td>
             <td><i class="ion-ios-checkmark text-success"></i></td>
             <td><i class="ion-ios-checkmark text-success"></i></td>
           </tr>
@@ -417,7 +407,20 @@
                 </div>
               </div>
             </th>
-            <td><i class="ion-close-circled text-muted"></i></td>
+            <td><i class="ion-ios-checkmark text-success"></i></td>
+            <td><i class="ion-ios-checkmark text-success"></i></td>
+            <td><i class="ion-ios-checkmark text-success"></i></td>
+          </tr>
+          <tr>
+            <th>
+              <div class="pricing__tooltip">
+                Reporting
+                <div class="pricing__tooltip--body">
+                  Get a longer term, aggregated overview on uptime and performance. Exports to CSV for further processing.
+                </div>
+              </div>
+            </th>
+            <td><i class="ion-ios-checkmark text-success"></i></td>
             <td><i class="ion-ios-checkmark text-success"></i></td>
             <td><i class="ion-ios-checkmark text-success"></i></td>
           </tr>


### PR DESCRIPTION
- merges triggers
- removes Opsgenie and Pagerduty. Adds it to just alerting channels.
- updates pricing example