### PR TITLE
feat: rewrite plausible script [ch-00]

### DIFF
--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -29,7 +29,7 @@
   <link rel="icon" type="image/png" href="/images/racoon_favicon.png" />
 
   <link rel="canonical" href="{{ .Permalink }}" />
-  <script async defer data-domain="checklyhq.com" src="https://plausible.io/js/plausible.js"></script>
+  <script async defer data-domain="checklyhq.com" src="/a/b.js"></script>
 
 
   <script async src="https://cdn.cookielaw.org/consent/e4c8a868-c0ad-4c0c-b61e-f6eb6cad2810.js" type="text/javascript" charset="UTF-8"></script>

--- a/vercel.json
+++ b/vercel.json
@@ -13,5 +13,11 @@
         "x-content-type-options": "nosniff"
       }
     }
+  ],
+	"rewrites": [
+    {
+      "source": "/a/b.js",
+      "destination": "https://plausible.io/js/plausible.js"
+    }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -4,17 +4,17 @@
   "build": {
     "env": {}
   },
-	"headers": [
-		{
-			"source": "/(.*)",
-			"headers" : [
-				{ "key": "x-frame-options", "value": "deny" },
-				{ "key": "x-xss-protection", "value": "0" },
-				{ "key": "x-content-type-options", "value": "nosniff" }
-			]
-		}
-	],
-	"rewrites": [
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers" : [
+        { "key": "x-frame-options", "value": "deny" },
+        { "key": "x-xss-protection", "value": "0" },
+        { "key": "x-content-type-options", "value": "nosniff" }
+      ]
+    }
+  ],
+  "rewrites": [
     {
       "source": "/a/b.js",
       "destination": "https://plausible.io/js/plausible.js"

--- a/vercel.json
+++ b/vercel.json
@@ -4,16 +4,16 @@
   "build": {
     "env": {}
   },
-  "routes": [
-    {
-      "src": "/.*",
-      "headers": {
-        "x-frame-options": "deny",
-        "x-xss-protection": "0",
-        "x-content-type-options": "nosniff"
-      }
-    }
-  ],
+	"headers": [
+		{
+			"source": "/(.*)",
+			"headers" : [
+				{ "key": "x-frame-options", "value": "deny" },
+				{ "key": "x-xss-protection", "value": "0" },
+				{ "key": "x-content-type-options", "value": "nosniff" }
+			]
+		}
+	],
 	"rewrites": [
     {
       "source": "/a/b.js",


### PR DESCRIPTION
So this was a little trick I found in the [plausible](https://plausible.io/docs/proxy/guides/nextjs) / vercel docs. It is kindddd of morally dubious, as we're actively going around users who use ad-blocking systems. But i don't find it that bad and plausible noted between 6%-29% of users have adblocking enabled (we're probably on the higher side with tech-savvy users).

So its up to you guys if we should merge this or not. If we do, the client will request `/a/b.js` on our own domain and vercel will do the work of serving `https://plausible.io/js/plausible.js` in its place.

**EDIT**: I implemented this with my instance of plausible on my homepage if you want to see what it looks like in the real world: https://ndo.dev/

**EDIT 2**: The `routes` key is apparently considered legacy and not compatible with rewrites, redirects, etc. so I upgraded it to the newer `headers` key. See: https://vercel.com/docs/configuration#project/routes/upgrading