### PR TITLE
feat: proxy plausible events endpoint as well

### DIFF
--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -29,7 +29,7 @@
   <link rel="icon" type="image/png" href="/images/racoon_favicon.png" />
 
   <link rel="canonical" href="{{ .Permalink }}" />
-  <script async defer data-domain="checklyhq.com" src="/a/b.js"></script>
+  <script async defer data-domain="checklyhq.com" data-api="/a/e" src="/a/b.js"></script>
 
 
   <script async src="https://cdn.cookielaw.org/consent/e4c8a868-c0ad-4c0c-b61e-f6eb6cad2810.js" type="text/javascript" charset="UTF-8"></script>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -22,7 +22,7 @@ $(document).ready(() => {
 })
 
 $(document).ready(() => {
-  console.log(`
+  console.log(`%c
        ,,,,,,         _ ,,,p##KBBKKBKKNpp,,, _      _ ,,,,,, _
      p#KKKKKKKKNw _,p##KKKKKKBKKKKKKKKKKKKKKKNp, _,u#KKKKKKKKNw
    _(#KPLL@@@2I#BKKKKKPP''L**5KKKKKKKPLLL*'*5KKKKKKBKLE@@@L|IKK_
@@ -52,7 +52,8 @@ KKKN|*5KKKKKKKKKKKKKKKKPL**''''_ __  ''''*|5$KKKKKKKKKKKKKKKBPLL#BKBLL*|$#KM'
    !KKH**''   ''*I#KN                        _;#KKL'''_ _''||#BKK' _
    _TKK@ _      _'IKKM                        #KK* _      _|$#K'_
     _KKNp         !##N_                      _#Kb_       _,##K"_
-     _"KKNp_   __,#KKP_                      _1KKp    _ ;##KM'_`)
+     _"KKNp_   __,#KKP_                      _1KKp    _ ;##KM'_`,
+  'color: #45c8f1; font-size: 9px;')
   console.log(`🚨 We're hiring, join us! https://checklyhq.com/jobs`)
 })
 

--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,7 @@
   "headers": [
     {
       "source": "/(.*)",
-      "headers" : [
+      "headers": [
         { "key": "x-frame-options", "value": "deny" },
         { "key": "x-xss-protection", "value": "0" },
         { "key": "x-content-type-options", "value": "nosniff" }
@@ -18,6 +18,10 @@
     {
       "source": "/a/b.js",
       "destination": "https://plausible.io/js/plausible.js"
+    },
+    {
+      "source": "/a/e",
+      "destination": "/api/event"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -21,7 +21,7 @@
     },
     {
       "source": "/a/e",
-      "destination": "/api/event"
+      "destination": "https://plausible.io/api/event"
     }
   ]
 }


### PR DESCRIPTION
In addition to the endpoint for the `plausible.js` snippet, we need to proxy the `/api/event` path because the snippet now attempts to write events to `checklyhq.com/api/event` instead of `plausible.io/api/event` - this of course also allows for gathering more accurate event data because the original endpoint (`plausible.io/api/event`) was also blocked by default through uBlock Origin.

---

Also, squeezed in a little console.log() css update to the hiring raccoon. The ascii raccoon was a bit distorted at the original font-size and I figured it couldn't hurt to match the brand colors while we're at it :) 

Before:
![image](https://user-images.githubusercontent.com/7415984/123837118-c43a7d80-d90a-11eb-8ff2-26f48aff23d1.png)

After:
![image](https://user-images.githubusercontent.com/7415984/123836846-70c82f80-d90a-11eb-8c92-ddfc975918c2.png)
