### PR TITLE
Changed highlighting syntax in learn code examples

### DIFF
--- a/site/content/learn/headless/basics-taking-screenshots.md
+++ b/site/content/learn/headless/basics-taking-screenshots.md
@@ -24,13 +24,13 @@ The `page.screenshot` command is consistent across Playwright and Puppeteer, and
 
 {{< tabs "1" >}}
 {{< tab "Playwright" >}}
-```js {hl_lines=[6,8]}
+```js
 {{< readfile filename="samples/playwright/basic-screenshot.js" >}}
 ```
 {{< run-in-checkly "/samples/playwright/basic-screenshot.js" "playwright"  >}}
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
-```js {hl_lines=[6,8]}
+```js 
 {{< readfile filename="samples/puppeteer/basic-screenshot.js" >}}
 ```
 {{< run-in-checkly "/samples/puppeteer/basic-screenshot.js" "puppeteer"  >}}

--- a/site/content/learn/headless/basics-taking-screenshots.md
+++ b/site/content/learn/headless/basics-taking-screenshots.md
@@ -24,13 +24,13 @@ The `page.screenshot` command is consistent across Playwright and Puppeteer, and
 
 {{< tabs "1" >}}
 {{< tab "Playwright" >}}
-```js {6,8}
+```js {hl_lines=[6,8]}
 {{< readfile filename="samples/playwright/basic-screenshot.js" >}}
 ```
 {{< run-in-checkly "/samples/playwright/basic-screenshot.js" "playwright"  >}}
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
-```js {6,8}
+```js {hl_lines=[6,8]}
 {{< readfile filename="samples/puppeteer/basic-screenshot.js" >}}
 ```
 {{< run-in-checkly "/samples/puppeteer/basic-screenshot.js" "puppeteer"  >}}

--- a/site/content/learn/headless/e2e-account-settings.md
+++ b/site/content/learn/headless/e2e-account-settings.md
@@ -25,12 +25,12 @@ On our [test site](https://danube-webshop.herokuapp.com/), such a test could loo
 
 {{< tabs "1">}}
 {{< tab "Playwright" >}}
-```js {18-21}
+```js {hl_lines=["19-22"]}
 {{< readfile filename="samples/playwright/file-upload.js" >}}
 ```
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
-```js {24-27}
+```js {hl_lines=["25-28"]}
 {{< readfile filename="samples/puppeteer/file-upload.js" >}}
 ```
 {{< /tab >}}

--- a/site/content/learn/headless/e2e-file-download.md
+++ b/site/content/learn/headless/e2e-file-download.md
@@ -31,12 +31,12 @@ We can approach this scenario in different ways. One possibility is to perform t
 
 {{< tabs "1" >}}
 {{< tab "Playwright" >}}
-```js {22-27}
+```js {hl_lines=["23-28"]}
 {{< readfile filename="samples/playwright/file-download.js" >}}
 ```
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
-```js {29-34}
+```js {hl_lines=["29-35"]}
 {{< readfile filename="samples/puppeteer/file-download.js" >}}
 ```
 {{< /tab >}}
@@ -48,7 +48,7 @@ Note that in this case, we need to enable downloads in the browser context befor
 
 {{< tabs "2" >}}
 {{< tab "Playwright" >}}
-```js {7,22-25,27}
+```js {hl_lines=["23-26"]}
 {{< readfile filename="samples/playwright/file-download-alt.js" >}}
 ```
 {{< /tab >}}

--- a/site/content/learn/headless/generating-pdfs.md
+++ b/site/content/learn/headless/generating-pdfs.md
@@ -24,12 +24,12 @@ After loading a page, we use the `page.pdf()` command to convert it to a PDF.
 
 {{< tabs "1" >}}
 {{< tab "Playwright" >}}
-```js {7}
+```js {hl_lines=[7]}
 {{< readfile filename="samples/playwright/pdf-minimal.js" >}}
 ```
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
-```js {7}
+```js {hl_lines=[7]}
 {{< readfile filename="samples/puppeteer/pdf-minimal.js" >}}
 ```
 {{< /tab >}}
@@ -56,12 +56,12 @@ We can also have custom headers and footers added to our pages, displaying value
 
 {{< tabs "2" >}}
 {{< tab "Playwright" >}}
-```js {10-11,21-31}
+```js {hl_lines=["11-12","21-31"]}
 {{< readfile filename="samples/playwright/pdf-hd.js" >}}
 ```
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
-```js {10-11,13,23-33}
+```js {hl_lines=["11-12","23-33"]}
 {{< readfile filename="samples/puppeteer/pdf-hd.js" >}}
 ```
 {{< /tab >}}

--- a/site/content/learn/headless/generating-pdfs.md
+++ b/site/content/learn/headless/generating-pdfs.md
@@ -56,12 +56,12 @@ We can also have custom headers and footers added to our pages, displaying value
 
 {{< tabs "2" >}}
 {{< tab "Playwright" >}}
-```js {hl_lines=["11-12","21-31"]}
+```js {hl_lines=["11-12","18-31"]}
 {{< readfile filename="samples/playwright/pdf-hd.js" >}}
 ```
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
-```js {hl_lines=["11-12","23-33"]}
+```js {hl_lines=["11-12","20-33"]}
 {{< readfile filename="samples/puppeteer/pdf-hd.js" >}}
 ```
 {{< /tab >}}

--- a/site/content/learn/headless/managing-cookies.md
+++ b/site/content/learn/headless/managing-cookies.md
@@ -26,12 +26,12 @@ The following examples show how we can save existing cookies after logging in to
 
 {{< tabs "1" >}}
 {{< tab "Playwright" >}}
-```js {20,21,23}
+```js {hl_lines=[21,22,24]}
 {{< readfile filename="samples/playwright/cookies-reading.js" >}}
 ```
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
-```js {18,19,21}
+```js {hl_lines=[19,20,22]}
 {{< readfile filename="samples/puppeteer/cookies-reading.js" >}}
 ```
 {{< /tab >}}
@@ -75,12 +75,12 @@ We are now able to read the file later and load the cookies into our new browser
 
 {{< tabs "2" >}}
 {{< tab "Playwright" >}}
-```js {8,10,11}
+```js {hl_lines=[9,11,12]}
 {{< readfile filename="samples/playwright/cookies-writing.js" >}}
 ```
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
-```js {8,10,11}
+```js {hl_lines=[9,11,12]}
 {{< readfile filename="samples/puppeteer/cookies-writing.js" >}}
 ```
 {{< /tab >}}
@@ -106,12 +106,12 @@ We will first fill the cart by adding three items, then we will copy the content
 
 {{< tabs "3" >}}
 {{< tab "Playwright" >}}
-```js {16,17}
+```js {hl_lines=[17,18]}
 {{< readfile filename="samples/playwright/localstorage-reading.js" >}}
 ```
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
-```js {21,22}
+```js {hl_lines=[22,23]}
 {{< readfile filename="samples/puppeteer/localstorage-reading.js" >}}
 ```
 {{< /tab >}}
@@ -129,12 +129,13 @@ We can use the content of this file to set localStorage in a separate session. T
 
 {{< tabs "4" >}}
 {{< tab "Playwright" >}}
-```js {10,12-17}
+```js {hl_lines=[10,"12-17"]}
+
 {{< readfile filename="samples/playwright/localstorage-writing.js" >}}
 ```
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
-```js {10,12-17}
+```js {hl_lines=[9,"11-16"]}
 {{< readfile filename="samples/puppeteer/localstorage-writing.js" >}}
 ```
 {{< /tab >}}

--- a/site/content/learn/headless/multitab-flows.md
+++ b/site/content/learn/headless/multitab-flows.md
@@ -61,7 +61,7 @@ Note that, if running Puppeteer in headful mode, you will have to manually bring
 
 {{< tabs "3" >}}
 {{< tab "Puppeteer" >}}
-```js {hl_lines=[20]}
+```js {hl_lines=["18-21"]}
 {{< readfile filename="samples/puppeteer/multitab-headful.js" >}}
 ```
 {{< run-in-checkly "/samples/puppeteer/multitab-headful.js" "puppeteer"  >}}

--- a/site/content/learn/headless/multitab-flows.md
+++ b/site/content/learn/headless/multitab-flows.md
@@ -61,7 +61,7 @@ Note that, if running Puppeteer in headful mode, you will have to manually bring
 
 {{< tabs "3" >}}
 {{< tab "Puppeteer" >}}
-```js {20}
+```js {hl_lines=[20]}
 {{< readfile filename="samples/puppeteer/multitab-headful.js" >}}
 ```
 {{< run-in-checkly "/samples/puppeteer/multitab-headful.js" "puppeteer"  >}}

--- a/site/content/learn/headless/request-interception.md
+++ b/site/content/learn/headless/request-interception.md
@@ -45,13 +45,13 @@ In the following snippet we are going to abort all requests for images on our te
 
 {{< tabs "2" >}}
 {{< tab "Playwright" >}}
-```js {hl_lines=["11-13"]}
+```js {hl_lines=["11-13", "16-20"]}
 {{< readfile filename="samples/playwright/request-interception-block.js" >}}
 ```
 {{< run-in-checkly "/samples/playwright/request-interception-block.js" "playwright"  >}}
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
-```js {hl_lines=[13,14]}
+```js {hl_lines=[13,14, "17-21"]}
 {{< readfile filename="samples/puppeteer/request-interception-block.js" >}}
 ```
 {{< run-in-checkly "/samples/puppeteer/request-interception-block.js" "puppeteer"  >}}

--- a/site/content/learn/headless/request-interception.md
+++ b/site/content/learn/headless/request-interception.md
@@ -45,13 +45,13 @@ In the following snippet we are going to abort all requests for images on our te
 
 {{< tabs "2" >}}
 {{< tab "Playwright" >}}
-```js {9-13}
+```js {hl_lines=["11-13"]}
 {{< readfile filename="samples/playwright/request-interception-block.js" >}}
 ```
 {{< run-in-checkly "/samples/playwright/request-interception-block.js" "playwright"  >}}
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
-```js {9-14}
+```js {hl_lines=[13,14]}
 {{< readfile filename="samples/puppeteer/request-interception-block.js" >}}
 ```
 {{< run-in-checkly "/samples/puppeteer/request-interception-block.js" "puppeteer"  >}}
@@ -76,13 +76,13 @@ Every time we load it, our test website is sending a request to its backend to f
 
 {{< tabs "3" >}}
 {{< tab "Playwright" >}}
-```js {19-24}
+```js {hl_lines=[18,23]}
 {{< readfile filename="samples/playwright/response-interception.js" >}}
 ```
 {{< run-in-checkly "/samples/playwright/response-interception.js" "playwright"  >}}
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
-```js {19-28}
+```js {hl_lines=[18,26]}
 {{< readfile filename="samples/puppeteer/response-interception.js" >}}
 ```
 {{< run-in-checkly "/samples/puppeteer/response-interception.js" "puppeteer"  >}}

--- a/src/scss/_syntax.scss
+++ b/src/scss/_syntax.scss
@@ -2,7 +2,7 @@
 /* Error */ .chroma .err { color: #960050; background-color: #1e0010 }
 /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
 /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; width: auto; overflow: auto; display: block; }
-/* LineHighlight */ .chroma .hl { display: block; width: 100%;background-color: #ffffcc }
+/* LineHighlight */ .chroma .hl { display: block; width: 100%;background-color: #575E38 }
 /* LineNumbersTable */ .chroma .lnt { margin-right: 0.4em; padding: 0 0.4em 0 0.4em; display: block; }
 /* LineNumbers */ .chroma .ln { margin-right: 0.4em; padding: 0 0.4em 0 0.4em; }
 /* Keyword */ .chroma .k { color: #66d9ef }


### PR DESCRIPTION
Resolves #167 

Changed highlighting syntax that wasn't working for [new one](https://gohugo.io/content-management/syntax-highlighting/), the old one was highlighting wrong lines of code or empty ones. You can check the sections where the changes were made and the previous/current highlighted lines with more detail bellow. @ragog could you please review them to see if the new ones are okay? thanks in advance! 

## 1 - E2E Account Settings

#### Playwright
- 18-21 to 19-22 to remove empty line
#### Puppeteer
- 24-27 to 25-28 to remove empty line

## 2 - E2E File Download

#### Playwright
- 22-27 to 23-28 to remove empty line
#### Puppeteer
- 29-34 to 29-35 added one more line at the end to include downloadUrl const usage Playwright 2

#### Playwright 2
- Changed to 23-26 to remove empty line and add one more at the end to include closing parenthesis

## 3 - Generating PDFS

### Customizing header and footer

#### Playwright
- 10-11,21-31 to 11-12,21-31 to remove empty line and added one more to highlight the creating of both constants (templateHeader and templateFooter)
#### Puppeteer
- Same as Playwright

## 4 - Managing Cookies

### Reading and writing cookies to the browser

#### Playwright (x2)
- 20,21,23 to 21,22,24 to remove empty line and include both const creations (cookies and cookiesJson) and their usage 
#### Puppeteer (x2)
- 18,19,21 to 19,20,22 to remove empty line and include both const creations (cookies and cookiesJson) and their usage 

### LocalStorage and SessionStorage

#### Playwright 
- 16,17 to 17,18 to remove empty line and include localStorage const creation and usage 
#### Puppeteer
- 21,22 to 22,23 to remove empty line and include localStorage const creation and usage 
#### Puppeteer 2
- 10,12-17 to 9,11-16 to match Playwright highlights 

## 5 - Request Interception

### Request Interception

#### Playwright
- 9,13 to 11-13 to remove empty line and include the complete condition
#### Puppeteer
- 9,13 to 13,14 to remove empty line and include the complete condition

### Response Interception

#### Playwright
- 19,24 to 18,23 to remove empty lines and include page creation and mockResponseObject usage
#### Puppeteer
- 19,28 to 18,26 to remove empty lines and include page creation and mockResponseObject usage