### PR TITLE
fix: remove x-frame-options header

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,16 +6,16 @@
   },
   "headers": [
     {
-      "source": "/(.*)",
+      "source": "/jamstackconf",
       "headers": [
-        { "key": "x-frame-options", "value": "deny" },
         { "key": "x-xss-protection", "value": "0" },
         { "key": "x-content-type-options", "value": "nosniff" }
       ]
     },
     {
-      "source": "/jamstackconf",
+      "source": "/(.*)",
       "headers": [
+        { "key": "x-frame-options", "value": "deny" },
         { "key": "x-xss-protection", "value": "0" },
         { "key": "x-content-type-options", "value": "nosniff" }
       ]

--- a/vercel.json
+++ b/vercel.json
@@ -8,14 +8,6 @@
     {
       "source": "/(.*)",
       "headers": [
-        { "key": "x-frame-options", "value": "deny" },
-        { "key": "x-xss-protection", "value": "0" },
-        { "key": "x-content-type-options", "value": "nosniff" }
-      ]
-    },
-    {
-      "source": "/jamstackconf",
-      "headers": [
         { "key": "x-xss-protection", "value": "0" },
         { "key": "x-content-type-options", "value": "nosniff" }
       ]

--- a/vercel.json
+++ b/vercel.json
@@ -8,6 +8,14 @@
     {
       "source": "/(.*)",
       "headers": [
+        { "key": "x-frame-options", "value": "deny" },
+        { "key": "x-xss-protection", "value": "0" },
+        { "key": "x-content-type-options", "value": "nosniff" }
+      ]
+    },
+    {
+      "source": "/jamstackconf",
+      "headers": [
         { "key": "x-xss-protection", "value": "0" },
         { "key": "x-content-type-options", "value": "nosniff" }
       ]
@@ -21,6 +29,10 @@
     {
       "source": "/a/e",
       "destination": "https://plausible.io/api/event"
+    },
+    {
+      "source": "/jamstackconf",
+      "destination": "/"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -6,16 +6,16 @@
   },
   "headers": [
     {
-      "source": "/jamstackconf",
+      "source": "/(.*)",
       "headers": [
+        { "key": "x-frame-options", "value": "deny" },
         { "key": "x-xss-protection", "value": "0" },
         { "key": "x-content-type-options", "value": "nosniff" }
       ]
     },
     {
-      "source": "/:path*",
+      "source": "/jamstackconf",
       "headers": [
-        { "key": "x-frame-options", "value": "deny" },
         { "key": "x-xss-protection", "value": "0" },
         { "key": "x-content-type-options", "value": "nosniff" }
       ]

--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,6 @@
     {
       "source": "/(.*)",
       "headers": [
-        { "key": "x-frame-options", "value": "deny" },
         { "key": "x-xss-protection", "value": "0" },
         { "key": "x-content-type-options", "value": "nosniff" }
       ]

--- a/vercel.json
+++ b/vercel.json
@@ -13,7 +13,7 @@
       ]
     },
     {
-      "source": "/(.*)",
+      "source": "/:path*",
       "headers": [
         { "key": "x-frame-options", "value": "deny" },
         { "key": "x-xss-protection", "value": "0" },


### PR DESCRIPTION
Remove the `x-frame-options: deny` header in order to allow our site to be embeded in frames. At the request of the jamstack conf people who want to embed our site somewhere.

We can add this back after the conference.