### PR TITLE
chore: add info about account ID [4933]

### DIFF
--- a/site/content/docs/accounts-and-users/creating-api-key.md
+++ b/site/content/docs/accounts-and-users/creating-api-key.md
@@ -25,6 +25,9 @@ The Checkly public API uses API keys to authenticate requests. API keys are uniq
 
 Use the API key as a Bearer token in the Authorization header when calling the Checkly API, e.g.
 
+You also need to set your target Account ID, you can find the Checkly Account ID under your [Account Settings](https://app.checklyhq.com/settings/account/general). If you don’t have access to account settings, please contact your account owner/admin.
+
+
 ```sh
 curl -H "Authorization: Bearer my_token" -H "X-Checkly-Account: my_account_ID" https://api.checklyhq.com/v1/checks
 ```


### PR DESCRIPTION
Add info about Account ID to Creating an API key section:

<img width="971" alt="Screenshot 2021-11-16 at 10 58 36" src="https://user-images.githubusercontent.com/76956254/141963821-f618e11b-0b89-4e7a-a3c1-f616248ccad8.png">
