### PR TITLE
feat: update docs for 2021.10

### DIFF
--- a/site/content/docs/runtimes/specs.md
+++ b/site/content/docs/runtimes/specs.md
@@ -5,7 +5,7 @@ menu:
   docs:
     parent: "Runtimes"
 aliases:
-    - /docs/browser-checks/runner-specification/
+  - /docs/browser-checks/runner-specification/
 ---
 
 By default, all our runners have their timezone set to UTC, regardless of their location.
@@ -16,6 +16,7 @@ By default, all our runners have their timezone set to UTC, regardless of their 
 - buffer
 - crypto
 - dns
+- faker
 - path
 - querystring
 - readline
@@ -28,7 +29,10 @@ By default, all our runners have their timezone set to UTC, regardless of their 
 - util
 - zlib
 
-See the [built-in module documentation on the official Node.js site](https://nodejs.org/dist/latest-v12.x/docs/api/)
+See the built-in module documentation on the official Node.js site:
+
+- [12.x](https://nodejs.org/dist/latest-v12.x/docs/api/)
+- [14.x](https://nodejs.org/dist/latest-v14.x/docs/api/)
 
 ## NPM packages
 

--- a/site/content/docs/runtimes/specs.md
+++ b/site/content/docs/runtimes/specs.md
@@ -16,7 +16,6 @@ By default, all our runners have their timezone set to UTC, regardless of their 
 - buffer
 - crypto
 - dns
-- faker
 - path
 - querystring
 - readline


### PR DESCRIPTION
Split the "built-in node modules docs" to a 12.x (from 2020.01) and a 14.x (2021.06 + 2021.10) link.

The runtime details toward the bottom of the page get autogenerated on build from the json served by the backend from `https://api.checklyhq.com/v1/runtimes`.