### PR TITLE
feat: now headers in the docs are direct links for handy copy & paste

### DIFF
--- a/site/layouts/docs/_markup/render-heading.html
+++ b/site/layouts/docs/_markup/render-heading.html
@@ -1,0 +1,6 @@
+<a class="heading-anchor" href="#{{ .Anchor | safeURL }}">
+
+<h{{ .Level }} id="{{ .Anchor | safeURL }}">
+{{ .Text | safeHTML }}
+</h{{ .Level }}>
+</a>

--- a/src/scss/_docs.scss
+++ b/src/scss/_docs.scss
@@ -37,7 +37,7 @@
       padding: 20px 0 20px 20px;
       overflow-x: hidden;
       overflow-y: auto;
-      
+
       border: 1px solid $gray-light;
       border-radius: 5px;
       ul {
@@ -265,6 +265,11 @@
     h1, h2, h3, h4, h5 {
       color: $black;
     }
+
+    .heading-anchor {
+      color: $black;
+    }
+
     .breadcrumb {
       display: flex;
       align-items: center;
@@ -272,7 +277,7 @@
       padding: 0;
       background: none;
       font-size: 14px;
-      
+
       & a {
         color: $gray;
         &:hover {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3802923/143020341-f1516758-16e4-4213-b81b-22cbd959063f.png)
