### PR TITLE
fix: add alias for team url [5412]

### DIFF
--- a/site/content/docs/accounts-and-users/_index.md
+++ b/site/content/docs/accounts-and-users/_index.md
@@ -5,6 +5,7 @@ menu:
   docs:
     parent: "Accounts & Users"
 aliases:
+- "/docs/teams/"
 - "/docs/teams/roles/"
 ---
 

--- a/site/content/docs/accounts-and-users/adding-team-members.md
+++ b/site/content/docs/accounts-and-users/adding-team-members.md
@@ -5,7 +5,7 @@ menu:
   docs:
     parent: "Accounts & Users"
 aliases:
-- "/docs/accounts-users/adding-team-members/"
+- "/docs/teams/adding-team-members/"
 ---
 
 You can invite team members to join your Checkly account to view and manage all checks and related settings.

--- a/site/content/docs/accounts-and-users/creating-api-key.md
+++ b/site/content/docs/accounts-and-users/creating-api-key.md
@@ -4,8 +4,6 @@ weight: 2
 menu:
   docs:
     parent: "Accounts & Users"
-aliases:
-- "/docs/accounts-users/creating-api-key/"
 ---
 
 The Checkly public API uses API keys to authenticate requests. API keys are unique to the user and not tied to an account. 


### PR DESCRIPTION
Currently the url for the team section (now "Account & Users") is dead link. This provides an alias to redirect to the "account and users" section. 