### PR TITLE
fix: changed based to scoped for consistency [5336]

### DIFF
--- a/site/content/docs/accounts-and-users/creating-api-key.md
+++ b/site/content/docs/accounts-and-users/creating-api-key.md
@@ -8,7 +8,7 @@ menu:
 
 The Checkly public API uses API keys to authenticate requests. API keys are unique to the user and not tied to an account. 
 
->Be aware that account-based API keys will be deprecated soon. Please create an API key for your user account in [User Settings](https://app.checklyhq.com/settings/user/).
+>Be aware that account-scoped API keys will be deprecated soon. Please create an API key for your user account in [User Settings](https://app.checklyhq.com/settings/user/).
 
 
 **Steps to create an API key:** 


### PR DESCRIPTION
Changing `account-based` to `account-scoped` to use the same terminology in the doc than in the web-app.


Deprecation warning in the web app: 
![Screenshot 2021-11-25 at 15 16 40](https://user-images.githubusercontent.com/76956254/143457313-5aa0c911-dc18-4e6d-bbd7-df88b46fb9bd.png)


