### PR TITLE
fix: typos in 'API Monitoring' and 'All features at a glance' sections

### DIFF
--- a/site/layouts/partials/all-features.html
+++ b/site/layouts/partials/all-features.html
@@ -21,7 +21,7 @@
       <div class="col-sm-6 col-md-6 col-lg-4">
         <div class="block third">
           <h5>CI/CD integration</h5>
-          <p><a class="info-link" href='/docs/cicd/triggers/'>Trigger your checks</a> on GitHub push & PR's or using a
+          <p><a class="info-link" href='/docs/cicd/triggers/'>Trigger your checks</a> on GitHub push & PR's or use a
             simple cURL command from your CI/CD pipeline.</p>
         </div>
       </div>

--- a/site/layouts/partials/api-monitoring-section.html
+++ b/site/layouts/partials/api-monitoring-section.html
@@ -4,7 +4,7 @@
       <div class="col-sm-12 col-md-10 col-lg-5">
         <div class="text-side text-left"><h2 class="section-super-header">api monitoring</h2>
           <h3 class="section-header">Monitor all your APIs easily</h3>
-          <p class="lead-text">Make sure your APIs always responds quickly and with the correct payload. Our intuitive editor lets you configure powerful HTTP requests.
+          <p class="lead-text">Make sure your APIs always respond quickly and with the correct payload. Our intuitive editor lets you configure powerful HTTP requests.
             <br><br>
             Kickstart your checks with our Swagger and cURL importer. Add Node.js-based setup/teardown scripts and fine-grained assertions for in-depth API monitoring.</p><a class="cta-link" href="/product/api-monitoring/">Learn
             more</a></div>


### PR DESCRIPTION
API Monitoring: `s/responds/respond`
All features at a glance: `s/using/use`