### PR TITLE
deleting hardcoded timezones

### DIFF
--- a/site/layouts/partials/jobs-embeded.html
+++ b/site/layouts/partials/jobs-embeded.html
@@ -47,7 +47,7 @@
       margin-bottom: 0 !important;
     }
     #whr_embed_hook  .whr-items .whr-item .whr-title:after {
-      content: 'Remote (GMT +/- 3 hours)';
+      content: 'Remote';
       display: block;
       font-size: 16px;
       font-weight: 400; 


### PR DESCRIPTION
Tiny change: Deleting hardcoded timezones on the careers page. 