### PR TITLE
feat: add redirect from docs.checklyhq.com -> checklyhq.com/docs [sc-00]

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -51,7 +51,7 @@
           "value": "docs.checklyhq.com"
         }
       ],
-      "destination": "/docs"
+      "destination": "https://www.checklyhq.com/docs"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -8,15 +8,27 @@
     {
       "source": "/(.*)",
       "headers": [
-        { "key": "x-frame-options", "value": "deny" },
-        { "key": "x-xss-protection", "value": "0" },
-        { "key": "x-content-type-options", "value": "nosniff" }
+        {
+          "key": "x-frame-options",
+          "value": "deny"
+        },
+        {
+          "key": "x-xss-protection",
+          "value": "0"
+        },
+        {
+          "key": "x-content-type-options",
+          "value": "nosniff"
+        }
       ]
     },
     {
       "source": "/(.*).(bmp|ico|icns|jpeg|pct|png|tiff|webp|svg)",
       "headers": [
-        { "key": "cache-control", "value": "max-age=86400, s-maxage=86400" }
+        {
+          "key": "cache-control",
+          "value": "max-age=86400, s-maxage=86400"
+        }
       ]
     }
   ],
@@ -28,6 +40,18 @@
     {
       "source": "/a/e",
       "destination": "https://plausible.io/api/event"
+    }
+  ],
+  "redirects": [
+    {
+      "source": "/",
+      "has": [
+        {
+          "key": "host",
+          "value": "docs.checklyhq.com"
+        }
+      ],
+      "destination": "/docs"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -47,7 +47,7 @@
       "source": "/",
       "has": [
         {
-          "key": "host",
+          "type": "host",
           "value": "docs.checklyhq.com"
         }
       ],


### PR DESCRIPTION
Rewrite requests to `docs.checklyhq.com` to `checklyhq.com/docs`

Following: https://vercel.com/support/articles/can-i-redirect-from-a-subdomain-to-a-subpath

Umut has already added a CNAME to point `docs.checklyhq.com` to `www.checklyhq.com` and thereby take us to the marketing page. From there, the `vercel.json` redirects added in this PR should take us the rest of the way :+1: 