### PR TITLE
fix: adjust mobile view of code editor [sc-8118]

### DIFF
--- a/src/scss/_product.scss
+++ b/src/scss/_product.scss
@@ -322,7 +322,7 @@
         }
         @include media-breakpoint-down(sm) {
           width: 100vw;
-          margin-left: calc(-50vw + 50% - 30px);
+          margin-left: calc(-50vw + 50%);
           filter: none;
           .code-block {
             width: 100%;


### PR DESCRIPTION
Code editor was not fitted to screen on mobile view.

Before:
![File](https://user-images.githubusercontent.com/54396648/165086189-419fbf2c-6881-4be0-aa71-ffd0c14441bc.jpg)



After:
<img width="354" alt="Screenshot 2022-04-25 at 13 05 12" src="https://user-images.githubusercontent.com/54396648/165085984-08e379ee-c1cd-4457-8240-ed96aa82c687.png">
