### PR TITLE
feat: document GROUP_NAME webhook var [sc-6126]

### DIFF
--- a/site/content/docs/alerting/webhooks.md
+++ b/site/content/docs/alerting/webhooks.md
@@ -43,6 +43,7 @@ You can use the following event-related variables in both URL and payload.
 | `SSL_CHECK_DOMAIN`  | The domain of the SSL certificate. For ALERT_SSL only.       |
 | `STARTED_AT`        | The ISO timestamp from when this check run started           |
 | `TAGS`              | An array of tags assigned to the check. Have a look at our Opsgenie example below on how to render this to a JSON array. |
+| `GROUP_NAME`        | The name of the group, if the check belongs to one.          |
 
 ## Using Handlebars helpers
 


### PR DESCRIPTION
We recently added the `GROUP_NAME` variable for WebHook alerts. If the check is assigned to a group, the `GROUP_NAME` variable contains the name of that group. If the check isn't assigned to any group, `GROUP_NAME` is undefined.

![image](https://user-images.githubusercontent.com/10483186/166903631-0d33a7cf-c1a7-4a58-b89a-f349be9de813.png)
