### PR TITLE
Learn headless adjustments

### DIFF
--- a/site/content/docs/runtimes/specs.md
+++ b/site/content/docs/runtimes/specs.md
@@ -30,8 +30,8 @@ By default, all our runners have their timezone set to UTC, regardless of their 
 
 See the built-in module documentation on the official Node.js site:
 
-- [12.x](https://nodejs.org/dist/latest-v12.x/docs/api/)
 - [14.x](https://nodejs.org/dist/latest-v14.x/docs/api/)
+- [12.x](https://nodejs.org/dist/latest-v12.x/docs/api/) (deprecated)
 
 ## NPM packages
 

--- a/site/content/learn/headless/avoiding-hard-waits.md
+++ b/site/content/learn/headless/avoiding-hard-waits.md
@@ -20,13 +20,13 @@ Looking to solve the issue of a page or element not being loaded, many take the 
 
 Hard waits do one thing and one thing only: wait for the specified amount of time. There is nothing more to them. This makes them dangerous: they are intuitive enough to be favoured by beginners and inflexbile enough to create serious issues.
 
-Let's explore these issues in practical terms through an example. Imagine the following situation: our script is running using a tool without any sort of built-in smart waiting, and we need to wait until an element appears on a page and then attempt to click it. We try to solve this issue with a hard wait, like Puppeteer's `page.waitFor(timeout)`. 
+Let's explore these issues in practical terms through an example. Imagine the following situation: our script is running using a tool without any sort of built-in smart waiting, and we need to wait until an element appears on a page and then attempt to click it. We try to solve this issue with a hard wait, like Puppeteer's `page.waitFor(timeout)`.
 
 This could looks something like the following:
 
 ```js
-await page.waitFor(1000); // hard wait for 1000ms
-await page.click('#button-login');
+await page.waitFor(1000) // hard wait for 1000ms
+await page.click('#button-login')
 ```
 
 In such a situation, the following can happen:
@@ -45,7 +45,7 @@ While the element is correctly clicked once our wait expires, and our script con
 
 In general, with hard waits we are virtually always waiting too little or too long. In the worst case scenario, the fluctuations in load time between different script executions are enough to make the wait sometimes too long and sometimes too short (meaning we will switch between scenario 1 and 2 from above in an unpredictable manner), making our script fail intermittently. That will result in unpredictable, seemingly random failures, also known as flakiness.
 
-Flakiness, a higher-than-acceptable false failure rate, can be a major problem. It is essentially a source of noise, making it harder to understand what the state of the system we are testing or monitoring really is. Not only that, but stakeholders who routinely need to investigate failures only to find out that they are script-related (instead of system-related) will rapidly lose confidence in an automation setup. 
+Flakiness, a higher-than-acceptable false failure rate, can be a major problem. It is essentially a source of noise, making it harder to understand what the state of the system we are testing or monitoring really is. Not only that, but stakeholders who routinely need to investigate failures only to find out that they are script-related (instead of system-related) will rapidly lose confidence in an automation setup.
 
 ## How to fix it
 
@@ -55,7 +55,7 @@ Our aim should be to wait just long enough for the element to appear. We want to
 
 ![playwright smart wait](/learn/images/smart_wait_01@2x.png)
 
-Different tools approach the broad topic of waiting in different ways. Both Puppeteer and Playwright offer many different kinds of smart waits, but Playwright takes things one step further and introduces an auto-waiting mechanism on most page interactions. 
+Different tools approach the broad topic of waiting in different ways. Both Puppeteer and Playwright offer many different kinds of smart waits, but Playwright takes things one step further and introduces an auto-waiting mechanism on most page interactions.
 
 Let's take a look at different smart waiting techniques and how they are used.
 
@@ -76,7 +76,7 @@ On a page load, we can use the following:
 1. `{{< newtabref title="page.waitForNavigation" href="https://playwright.dev/docs/api/class-page#page-wait-for-navigation" >}}` to wait until a page navigation (new URL or page reload) has completed.
 2. `{{< newtabref title="page.waitForLoadState" href="https://playwright.dev/docs/api/class-page#page-wait-for-load-state" >}}` for Playwright, waits until the required load state has been reached (defaults to `load`); `{{< newtabref title="page.waitForNetworkIdle" href="https://pptr.dev/#?product=Puppeteer&show=api-pagewaitfornetworkidleoptions" >}}` with Puppeteer, a narrower method to wait until all network calls have ended.
 3. `{{< newtabref title="page.waitForURL" href="https://playwright.dev/docs/api/class-page#page-wait-for-url" >}}` with Playwright, waits until a navigation to the target URL.
-	
+
 All the above default to waiting for the `{{< newtabref title="load" href="https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event" >}}` event, but can also be set to wait for:
 * the `{{< newtabref title="DOMContentLoaded" href="https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event" >}}` event.
 * Playwright only: `networkidle`, raised when there are no network connections for at least 500 ms.
@@ -91,10 +91,10 @@ Additionally, we can also wait until a specific request is sent out or a specifi
 ### Waiting for an element
 
 We can also explicitly wait for a specific element to appear on the page. This is normally done via `{{< newtabref title="page.waitForSelector" href="https://playwright.dev/docs/api/class-page#page-wait-for-selector" >}}` or a similar method, like `{{< newtabref title="page.waitForXPath" href="https://pptr.dev/#?product=Puppeteer&show=api-pagewaitforxpathxpath-options" >}}` (Puppeteer only). A good knowledge of [selectors](/learn/headless/basics-selectors) is key to enable us to select precisely the element we need to wait for.
-	
+
 ### Waiting on page events
 
-With Playwright, we can also directly wait on {{< newtabref title="page events" href="https://playwright.dev/docs/events" >}} using `{{< newtabref title="page.waitForEvent" href="https://playwright.dev/docs/api/class-page#page-wait-for-event" >}}`. 
+With Playwright, we can also directly wait on {{< newtabref title="page events" href="https://playwright.dev/docs/events" >}} using `{{< newtabref title="page.waitForEvent" href="https://playwright.dev/docs/api/class-page#page-wait-for-event" >}}`.
 
 ### Waiting on page functions
 

--- a/site/content/learn/headless/basics-clicking-typing.md
+++ b/site/content/learn/headless/basics-clicking-typing.md
@@ -29,9 +29,9 @@ Clicking is the default way of selecting and activating elements on web pages, a
 {{< tabs "1">}}
 {{< tab "Playwright" >}}
  ```js
-const { chromium } = require('playwright');
+const { chromium } = require('playwright')
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const page = await browser.newPage()
   await page.goto('https://danube-webshop.herokuapp.com/')
@@ -44,9 +44,9 @@ const { chromium } = require('playwright');
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
  ```js
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer')
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
   await page.goto('https://danube-webshop.herokuapp.com/')
@@ -72,9 +72,9 @@ A popular pattern among web pages is exposing additional information or function
 {{< tabs "3" >}}
 {{< tab "Playwright" >}}
  ```js
-const { chromium } = require('playwright');
+const { chromium } = require('playwright')
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const page = await browser.newPage()
   await page.goto('https://danube-webshop.herokuapp.com/')
@@ -87,9 +87,9 @@ const { chromium } = require('playwright');
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
  ```js
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer')
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
   await page.goto('https://danube-webshop.herokuapp.com/')
@@ -110,9 +110,9 @@ Focussing on specific UI elements allows the user to interact with them without 
 {{< tabs "4" >}}
 {{< tab "Playwright" >}}
  ```js
-const { chromium } = require('playwright');
+const { chromium } = require('playwright')
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const page = await browser.newPage()
   await page.goto('https://danube-webshop.herokuapp.com/')
@@ -125,9 +125,9 @@ const { chromium } = require('playwright');
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
  ```js
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer')
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
   await page.goto('https://danube-webshop.herokuapp.com/')
@@ -148,9 +148,9 @@ We can simulate typing on a real keyboard using `page.type()`:
 {{< tabs "5" >}}
 {{< tab "Playwright" >}}
  ```js
-const { chromium } = require('playwright');
+const { chromium } = require('playwright')
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const page = await browser.newPage()
   await page.goto('https://danube-webshop.herokuapp.com/')
@@ -163,9 +163,9 @@ const { chromium } = require('playwright');
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
  ```js
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer')
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
   await page.goto('https://danube-webshop.herokuapp.com/')

--- a/site/content/learn/headless/basics-clicking-typing.md
+++ b/site/content/learn/headless/basics-clicking-typing.md
@@ -32,13 +32,13 @@ Clicking is the default way of selecting and activating elements on web pages, a
 const { chromium } = require('playwright');
 
 (async () => {
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
-  await page.goto('https://danube-webshop.herokuapp.com/');
+  const browser = await chromium.launch()
+  const page = await browser.newPage()
+  await page.goto('https://danube-webshop.herokuapp.com/')
 
-  await page.click('#login');
+  await page.click('#login')
 
-  await browser.close();
+  await browser.close()
 })()
  ```
 {{< /tab >}}
@@ -47,14 +47,14 @@ const { chromium } = require('playwright');
 const puppeteer = require('puppeteer');
 
 (async () => {
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
-  await page.goto('https://danube-webshop.herokuapp.com/');
+  const browser = await puppeteer.launch()
+  const page = await browser.newPage()
+  await page.goto('https://danube-webshop.herokuapp.com/')
 
-  await page.waitForSelector('#login');
-  await page.click('#login');
+  await page.waitForSelector('#login')
+  await page.click('#login')
 
-  await browser.close();
+  await browser.close()
 })()
  ```
 {{< /tab >}}
@@ -75,13 +75,13 @@ A popular pattern among web pages is exposing additional information or function
 const { chromium } = require('playwright');
 
 (async () => {
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
-  await page.goto('https://danube-webshop.herokuapp.com/');
+  const browser = await chromium.launch()
+  const page = await browser.newPage()
+  await page.goto('https://danube-webshop.herokuapp.com/')
 
-  await page.hover('a');
+  await page.hover('a')
 
-  await browser.close();
+  await browser.close()
 })()
  ```
 {{< /tab >}}
@@ -90,14 +90,14 @@ const { chromium } = require('playwright');
 const puppeteer = require('puppeteer');
 
 (async () => {
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
-  await page.goto('https://danube-webshop.herokuapp.com/');
+  const browser = await puppeteer.launch()
+  const page = await browser.newPage()
+  await page.goto('https://danube-webshop.herokuapp.com/')
 
-  await page.waitForSelector('a');
-  await page.hover('a');
+  await page.waitForSelector('a')
+  await page.hover('a')
 
-  await browser.close();
+  await browser.close()
 })()
  ```
 {{< /tab >}}
@@ -113,13 +113,13 @@ Focussing on specific UI elements allows the user to interact with them without 
 const { chromium } = require('playwright');
 
 (async () => {
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
-  await page.goto('https://danube-webshop.herokuapp.com/');
+  const browser = await chromium.launch()
+  const page = await browser.newPage()
+  await page.goto('https://danube-webshop.herokuapp.com/')
 
-  await page.focus('input');
+  await page.focus('input')
 
-  await browser.close();
+  await browser.close()
 })()
  ```
 {{< /tab >}}
@@ -128,14 +128,14 @@ const { chromium } = require('playwright');
 const puppeteer = require('puppeteer');
 
 (async () => {
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
-  await page.goto('https://danube-webshop.herokuapp.com/');
+  const browser = await puppeteer.launch()
+  const page = await browser.newPage()
+  await page.goto('https://danube-webshop.herokuapp.com/')
 
-  await page.waitForSelector('input');
-  await page.focus('input');
+  await page.waitForSelector('input')
+  await page.focus('input')
 
-  await browser.close();
+  await browser.close()
 })()
  ```
 {{< /tab >}}
@@ -151,13 +151,13 @@ We can simulate typing on a real keyboard using `page.type()`:
 const { chromium } = require('playwright');
 
 (async () => {
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
-  await page.goto('https://danube-webshop.herokuapp.com/');
+  const browser = await chromium.launch()
+  const page = await browser.newPage()
+  await page.goto('https://danube-webshop.herokuapp.com/')
 
-  await page.fill('input', 'some search terms');
+  await page.fill('input', 'some search terms')
 
-  await browser.close();
+  await browser.close()
 })()
  ```
 {{< /tab >}}
@@ -166,14 +166,14 @@ const { chromium } = require('playwright');
 const puppeteer = require('puppeteer');
 
 (async () => {
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
-  await page.goto('https://danube-webshop.herokuapp.com/');
+  const browser = await puppeteer.launch()
+  const page = await browser.newPage()
+  await page.goto('https://danube-webshop.herokuapp.com/')
 
   await page.waitForSelector('input')
-  await page.type('input', 'some search terms');
+  await page.type('input', 'some search terms')
 
-  await browser.close();
+  await browser.close()
 })()
  ```
 {{< /tab >}}
@@ -190,9 +190,9 @@ Key presses can also be sent to a specific element:
 We can also hold down and release one or more keys, possibly combining them to use keyboard shortcuts:
 
 ```js
-await page.keyboard.down('Control');
-await page.keyboard.press('V');
-await page.keyboard.up('Control');
+await page.keyboard.down('Control')
+await page.keyboard.press('V')
+await page.keyboard.up('Control')
 ```
 
 You can run (from the terminal) the above examples as follows:

--- a/site/content/learn/headless/basics-debugging.md
+++ b/site/content/learn/headless/basics-debugging.md
@@ -12,7 +12,7 @@ menu:
     parent: "Getting started"
 ---
 
-Understanding why a script does not work as expected, or just what the root cause of a failure is, is a key skill for automation. Given its importance and its sometimes deceptive complexity, debugging is a topic that should receive quite some attention. 
+Understanding why a script does not work as expected and finding the failure root cause are automation key skills. Given its importance and its sometimes deceptive complexity, debugging is a topic that should receive quite some attention.
 
 This article will explore basic concepts and tools to point beginners in the right direction.
 
@@ -25,7 +25,7 @@ Script debugging is firstly about observing and understanding. Finding out what 
 1. What the script you are looking at is _supposed_ to do
 2. How the application the script is running against is supposed to behave at each step of the script
 
-When approaching a debugging session, make sure the above points are taken care of. Skipping this step is way more likely to cost you additional time than it is to save you any. 
+When approaching a debugging session, make sure the above points are taken care of. Skipping this step is way more likely to cost you additional time than it is to save you any.
 
 ## The error message
 
@@ -39,7 +39,7 @@ Do not fall into the easy trap of reading the error message and immediately jump
 
 ## Gaining visibility
 
-Given that Headless browser scripts will run without a GUI, a visual assessment of the state of the application needs additional steps. 
+Given that Headless browser scripts will run without a GUI, a visual assessment of the state of the application needs additional steps.
 
 One possibility is to adding screenshots in specific parts of the script, to validate our assumptions on what might be happening at a given moment of the execution. For example, before and after a problematic click or page transition:
 
@@ -47,19 +47,19 @@ One possibility is to adding screenshots in specific parts of the script, to val
 {{< tab "Playwright" >}}
 ```js
 ...
-await page.screenshot({ path: 'before_click.png' });
+await page.screenshot({ path: 'before_click.png' })
 await page.click('#button')
-await page.screenshot({ path: 'after_click.png' });
+await page.screenshot({ path: 'after_click.png' })
 ...
 ```
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
 ```js
 ...
-await page.screenshot({ path: 'before_click.png' });
-await page.waitForSelector('#button');
+await page.screenshot({ path: 'before_click.png' })
+await page.waitForSelector('#button')
 await page.click('#button')
-await page.screenshot({ path: 'after_click.png' });
+await page.screenshot({ path: 'after_click.png' })
 ...
 ```
 {{< /tab >}}
@@ -71,14 +71,14 @@ Another way to better observe our script's execution is to run in headful mode:
 {{< tab "Playwright" >}}
 ```js
 ...
-const browser = await chromium.launch({ headless: false, slowMo: 20 });
+const browser = await chromium.launch({ headless: false, slowMo: 20 })
 ...
 ```
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
 ```js
 ...
-const browser = await puppeteer.launch({ headless: false, slowMo: 20 });
+const browser = await puppeteer.launch({ headless: false, slowMo: 20 })
 ...
 ```
 {{< /tab >}}
@@ -105,7 +105,7 @@ DEBUG="puppeteer:*" node script.js
 
 ![verbose playwright logs](/samples/images/debugging-logging.png)
 
-## Accessing DevTools 
+## Accessing DevTools
 
 A wealth of information is available through the Chrome Developer Tools. We can configure our browser to start with the DevTools tab already open (this will automatically disable headless mode), which can be helpful when something is not working as expected. Careful inspection of the Console, Network and other tabs can reveal hidden errors and other important findings.
 
@@ -115,14 +115,14 @@ A wealth of information is available through the Chrome Developer Tools. We can 
 {{< tab "Playwright" >}}
 ```js
 ...
-await chromium.launch({ devtools: true });
+await chromium.launch({ devtools: true })
 ...
 ```
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
 ```js
 ...
-await browser.launch({ devtools: true });
+await browser.launch({ devtools: true })
 ...
 ```
 {{< /tab >}}

--- a/site/content/learn/headless/basics-local-setup.md
+++ b/site/content/learn/headless/basics-local-setup.md
@@ -71,13 +71,13 @@ When you are first writing and debugging your scripts, it is a good idea to disa
 
 {{< tab "Playwright" >}}
 ```js
-const browser = await chromium.launch({ headless: false });
+const browser = await chromium.launch({ headless: false })
 ```
 {{< /tab >}}
 
 {{< tab "Puppeteer" >}}
 ```js
-const browser = await puppeteer.launch({ headless: false });
+const browser = await puppeteer.launch({ headless: false })
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/site/content/learn/headless/basics-navigation.md
+++ b/site/content/learn/headless/basics-navigation.md
@@ -14,13 +14,12 @@ menu:
     parent: "Getting started"
 ---
 
-Every useful script that we will write will almost certainly do three key things:
+Every script that we will write will almost certainly do three key things:
 1. Navigating to some web page
 2. Waiting for something
 3. Possibly getting a timeout 😐
 
-Both frameworks handle these scenarios in very similar ways but Playwright explicitly differentiates itself from Puppeteer
-by having a "built in" waiting mechanism that covers a lot of common scenarios.
+> Both frameworks handle these scenarios in very similar ways but [Playwright explicitly differentiates itself from Puppeteer by having a "built-in" waiting mechanism](https://playwright.dev/docs/actionability) that covers many common scenarios.
 
 <!-- more -->
 
@@ -73,7 +72,7 @@ needs to be loaded after clicking, hovering, navigating etc. You can pass it an 
 to override the default 30 seconds.
 
 In the example below, we type an email address into an input field on a login modal. Notice the difference between
-the Playwright and Puppeteer example.
+the Playwright and Puppeteer example. Playwright's `fill` method comes with built-in waiting functionality.
 
 {{< tabs "2" >}}
 {{< tab "Playwright" >}}

--- a/site/content/learn/headless/basics-selectors.md
+++ b/site/content/learn/headless/basics-selectors.md
@@ -14,7 +14,7 @@ menu:
     parent: "Getting started"
 ---
 
-With Puppeteer and Playwright, as well as with most other UI automation tools, elements on the UI are referenced through element selectors. Becoming proficient in the use of selectors is a hard requirement for writing scripts; an eye for good, solid selectors can make the difference between unstable (or "flaky") high-maintenace script and solid, reliable ones.
+Puppeteer, Playwright and most other UI automation tools reference UI elements through selectors. Becoming proficient in the use of selectors is a hard requirement for writing scripts. An eye for good, solid selectors can make the difference between unstable (or "flaky") high-maintenace scripts and solid, reliable ones.
 
 This guide aims to get new users started with selectors, and to serve a refresher for more experienced automators. Even though some content will be specific to Puppeteer and Playwright, most principles will apply to most, if not all, UI automation tools.
 
@@ -22,7 +22,7 @@ This guide aims to get new users started with selectors, and to serve a refreshe
 
 ## Different types of selectors
 
-Depending on the tool and the application being tested, different kind of selectors might be available. Puppeteer and Playwright share two main types of selector:
+Depending on the tool and the application being tested, different kind of selectors might be available. Puppeteer and Playwright share two main selector types:
 
 1. [CSS selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors)
 2. [XPath selectors](https://developer.mozilla.org/en-US/docs/Web/XPath)
@@ -44,7 +44,7 @@ Originally used to target HTML elements for [applying CSS rules](https://develop
 Examples:
 1. `#add-to-cart` selects the item with id `add-to-cart`, e.g. `<button id="add-to-cart">Buy</button>`
 2. `.preview` selects the item with class `preview`, e.g. `<li data-v-5ad54829="" class="preview">...</li>`
-3. `.preview .preview-price` selects the item with class `price` within the element with class `preview`
+3. `.preview .preview-price` selects the item with class `preview-price` within the element with class `preview`
 4. `[data-test=login-button]` selects the item with attribute `data-test` equal to `login-button`, e.g. `<button id="btn-login" aria-label="Log in" data-test="login-button">Log in</button>`
 5. `a.preview-link` selects the item of type `a` with class `preview-link`, e.g. `<a href="https://example.com/ class="preview-link">Example</a>"`
 6. `#navbar > .button-cart` selected the item with class `button-cart` within the item with id `navbar`
@@ -68,7 +68,7 @@ Examples:
 Text selectors allow selecting an element via its text content directly. They are Playwright-specific.
 
 Examples:
-1. `text=Add` selects the element containing text `Add`, `add` or similar (case insensitive) 
+1. `text=Add` selects the element containing text `Add`, `add` or similar (case insensitive)
 2. `text="Add to cart"` selects the element containing exactly the text `Add to cart`
 
 ### Playwright-specific selectors
@@ -83,7 +83,7 @@ Examples:
 With Playwright, multiple selectors of different types can be combined to reference elements relative to other elements.
 
 Examples:
-1. `css=preview >> text=In stock` selects the item with class `preview` and text content `In stock`, `in stock` or similar (case insensitive) 
+1. `css=preview >> text=In stock` selects the item with class `preview` and text content `In stock`, `in stock` or similar (case insensitive)
 
 ## Finding selectors
 
@@ -97,7 +97,7 @@ Once you know enough about selectors, looking at a page's HTML will be enough to
 
 ### Inspecting the page
 
-You can also use your browser's inspector tool, as found e.g. in the [Chrome Dev Tools](https://developers.google.com/web/tools/chrome-devtools/dom), to highlight elements on the page and see their attributes. 
+You can also use your browser's inspector tool, as found e.g. in the [Chrome Dev Tools](https://developers.google.com/web/tools/chrome-devtools/dom), to highlight elements on the page and see their attributes.
 
 ![getting selectors via the browser inspector](/samples/images/selectors-inspector.png)
 
@@ -133,19 +133,19 @@ We can also test our selectors directly in the browser, before touching our scri
 
 Similarly, we can test XPath selectors using `$x(<selector>)`, which will return all the element matching our criteria.
 
-The Playwright-specific selectors can be tested by running the Playwright Inspector, which will provision a `playwright` object for access in the console. 
+The Playwright-specific selectors can be tested by running the Playwright Inspector, which provisions an accessible `playwright` object in the console.
 
 ![playwright inspector object in console](/samples/images/selectors-pwobject.png)
 
 ## Choosing selectors
 
-The selectors you choose to use in your scripts will help determine how much maintenance work will go into your scripts over the course of their lifetime. Ideally, you want to have robust selectors in place since the inception of the script to save yourself time and effort going forward.
+The selectors you choose to use in your scripts will help determine how much maintenance work will go into your scripts over the course of their lifetime. Ideally, you want to have robust selectors in place to save yourself time and effort going forward.
 
 The attributes of a good selector are:
 
-- **Uniqueness**: the goal is to choose something that will identify the target element, and nothing else; [IDs](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors#ID_Selectors) are the natural choice, when available.
-- **Stability**: choosing an attribute that is not likely to change over time as the page gets updated lowers the chances that you will need to manually update it.
-- **Conciseness**: a short selector is easier to read, understand and possibly replace if it finally breaks.
+- **Uniqueness**: choose a selector that will identify the target element, and nothing else; [IDs](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors#ID_Selectors) are the natural choice, when available.
+- **Stability**: use an attribute that is unlikely to change as the page gets updated lowers the chances that you will need to manually update it.
+- **Conciseness**: prefer short selectors that are easier to read, understand and possibly replace if a script breaks.
 
 ### Examples of bad selectors
 
@@ -155,7 +155,7 @@ Avoid this kind of selector *whenever possible:*
     - not concise
     - likely not stable: class names are auto-generated, they could change rapidly
 2. `.g:nth-child(3) > .rc`
-    - likely not stable: is the third child of .g always going to be present?
+    - likely not stable: is the third child of `.g` always going to be present?
     - likely not unique: is it always going to be the right element?
 3. `a[data-v-9a19ef14]`
     - not stable: attribute is [auto-generated](https://vue-loader.vuejs.org/guide/scoped-css.html#scoped-css) and changes between deployments

--- a/site/content/learn/headless/basics-taking-screenshots.md
+++ b/site/content/learn/headless/basics-taking-screenshots.md
@@ -20,7 +20,7 @@ Headless browsers are fully capable of taking screenshots, which is very useful 
 
 ## Generating and saving screenshots
 
-The `page.screenshot` command is consistent across Playwright and Puppeteer, and allows us to save one or more screenshots of the current page to a specified path. Without any additional options, the size of the screenshot will depend on that of the viewport:
+The `page.screenshot` command is consistent across Playwright and Puppeteer, and allows us to save one or more screenshots of the current page to a specified path. Without any additional options, the size of the screenshot depends on the viewport size:
 
 {{< tabs "1" >}}
 {{< tab "Playwright" >}}
@@ -30,7 +30,7 @@ The `page.screenshot` command is consistent across Playwright and Puppeteer, and
 {{< run-in-checkly "/samples/playwright/basic-screenshot.js" "playwright"  >}}
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
-```js 
+```js
 {{< readfile filename="samples/puppeteer/basic-screenshot.js" >}}
 ```
 {{< run-in-checkly "/samples/puppeteer/basic-screenshot.js" "puppeteer"  >}}

--- a/site/content/learn/headless/challenging-flows.md
+++ b/site/content/learn/headless/challenging-flows.md
@@ -47,19 +47,19 @@ Bot detection could be deactivated for pre-production environments in order to a
 {{< tabs "1">}}
 {{< tab "Playwright" >}}
 ```js
-const browser = await chromium.launch();
+const browser = await chromium.launch()
 const context = await browser.newContext({
   userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/79.0.3945.0 Safari 537.36 Secret/<MY_SECRET>'
-});
-const page = await context.newPage('https://example.com');
+})
+const page = await context.newPage('https://example.com')
 
 ```
 {{< /tab >}}
 {{< tab "Puppeteer" >}}
  ```js
-const browser = await puppeteer.launch();
-const page = await browser.newPage();
-await page.setUserAgent('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/79.0.3945.0 Safari 537.36 Secret/<MY_SECRET>');
+const browser = await puppeteer.launch()
+const page = await browser.newPage()
+await page.setUserAgent('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/79.0.3945.0 Safari 537.36 Secret/<MY_SECRET>')
 
 ```
 {{< /tab >}}

--- a/site/content/learn/headless/e2e-file-download.md
+++ b/site/content/learn/headless/e2e-file-download.md
@@ -48,7 +48,7 @@ Note that in this case, we need to enable downloads in the browser context befor
 
 {{< tabs "2" >}}
 {{< tab "Playwright" >}}
-```js {hl_lines=["23-26"]}
+```js {hl_lines=["8", "23-26"]}
 {{< readfile filename="samples/playwright/file-download-alt.js" >}}
 ```
 {{< /tab >}}

--- a/site/content/learn/headless/e2e-microsoft-live-login.md
+++ b/site/content/learn/headless/e2e-microsoft-live-login.md
@@ -35,7 +35,7 @@ Playwright and Puppeteer also allow us to automate logging in to a Microsoft Liv
 {{< readfile filename="samples/puppeteer/mslive-login.js" >}}
 ```
 {{< /tab >}}
-{{< /tab >}}:
+{{< /tab >}}
 
 Run this example as follows. Replace the username and password placeholder with your own credentials.
 

--- a/site/content/learn/headless/managing-cookies.md
+++ b/site/content/learn/headless/managing-cookies.md
@@ -100,7 +100,7 @@ In case you need to clear cookies, you can use [`page.deleteCookie(...cookies)`]
 
 Cookies are sent with every request, potentially deteriorating [performance](/learn/headless/basics-performance/) if used for storing large amounts of data. The [localStorage and sessionStorage](https://javascript.info/localstorage) APIs can help us offload some of this data to the browser. Just like with cookies, Playwright and Puppeteer make accessing localStorage and sessionStorage straightforward.
 
-Our test site, [Danube](https://danube-webshop.herokuapp.com/), actually uses localStorage to keep track of a few things, such as the content of your cart. Let's see how we can access this state and then replicate it in a later session.
+Our test site, [Danube](https://danube-webshop.herokuapp.com/), actually uses localStorage to keep track of things such as the content of your cart. Let's see how we can access this state and then replicate it in a later session.
 
 We will first fill the cart by adding three items, then we will copy the contents of localStorage to a file.
 

--- a/site/content/learn/headless/request-interception.md
+++ b/site/content/learn/headless/request-interception.md
@@ -16,7 +16,7 @@ menu:
     parent: "Network & state"
 ---
 
-When we browse the web, a series of HTTP requests and responses are exchanged between our browser and the pages we are visiting. There are scenarios in which it is useful to monitor or manipulate this traffic, instead of letting it happen as-is.
+When we browse the web, a series of HTTP requests and responses are exchanged between our browser and the pages we are visiting. There are scenarios in which it is useful to monitor or manipulate this traffic.
 
 <!-- more -->
 

--- a/site/content/learn/headless/test-data-intro.md
+++ b/site/content/learn/headless/test-data-intro.md
@@ -42,11 +42,11 @@ Looking at our [test webshop](https://danube-store.herokuapp.com/), we might wan
 We are then able to feed this file into our test...
 
 ```js
-const fs = require('fs');
+const fs = require('fs')
 ...
-let rawdata = fs.readFileSync('books.json');
-const bookList = JSON.parse(rawdata);
-const foundList = bookList;
+let rawdata = fs.readFileSync('books.json')
+const bookList = JSON.parse(rawdata)
+const foundList = bookList
 ```
 
 ...and have each comparison executed to ensure the right elements are being shown.
@@ -70,9 +70,9 @@ In case the platform you are testing exposes an API endpoint to pull up-to-date 
 ```js
 const axios = require('axios');
 ...
-const { data } = await axios.get('https://danube-store.herokuapp.com/api/books');
-const bookList = JSON.parse(data);
-const foundList = bookList;
+const { data } = await axios.get('https://danube-store.herokuapp.com/api/books')
+const bookList = JSON.parse(data)
+const foundList = bookList
 ```
 
 ## Takeaways

--- a/site/content/learn/headless/valuable-tests.md
+++ b/site/content/learn/headless/valuable-tests.md
@@ -13,7 +13,7 @@ menu:
     parent: "Best practices"
 ---
 
-Headless browsers can be leveraged for testing in a variety of ways, and different scenarios do command different approaches. That being said, there are some general pointers most should follow in order to keep their tests _valuable_.
+Headless browsers can be leveraged for testing in a variety of ways, and different scenarios do command different approaches. There are some general pointers most should follow in order to keep their tests _valuable_.
 
 Here, we define _valuable_ as _sustainably expressing meaningful, truthful information about the state of a system_.
 A test that does not reliably fulfill these criteria should be fixed, if possible, or simply removed.

--- a/site/content/samples/playwright/basic-browser-navigation.js
+++ b/site/content/samples/playwright/basic-browser-navigation.js
@@ -1,6 +1,6 @@
-const { chromium } = require('playwright');
+const { chromium } = require('playwright')
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const page = await browser.newPage()
   await page.goto('https://danube-webshop.herokuapp.com')

--- a/site/content/samples/playwright/basic-browser-waiting.js
+++ b/site/content/samples/playwright/basic-browser-waiting.js
@@ -1,6 +1,6 @@
-const { chromium } = require('playwright');
+const { chromium } = require('playwright')
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const context = await browser.newContext()
   const page = await context.newPage()

--- a/site/content/samples/playwright/basic-click-type.js
+++ b/site/content/samples/playwright/basic-click-type.js
@@ -1,13 +1,13 @@
-const { chromium } = require("playwright");
+const { chromium } = require('playwright')
 
-(async () => {
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
-  await page.goto("https://danube-webshop.herokuapp.com/");
+;(async () => {
+  const browser = await chromium.launch()
+  const page = await browser.newPage()
+  await page.goto('https://danube-webshop.herokuapp.com/')
 
-  await page.fill("input", "some search terms");
+  await page.fill('input', 'some search terms')
 
-  await page.click("button");
+  await page.click('button')
 
-  await browser.close();
-})();
+  await browser.close()
+})()

--- a/site/content/samples/playwright/basic-get-data-json.js
+++ b/site/content/samples/playwright/basic-get-data-json.js
@@ -1,29 +1,28 @@
-const { chromium } = require("playwright");
-const fs = require("fs");
+const { chromium } = require('playwright')
+const fs = require('fs')
 
-(async () => {
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
-  await page.goto("https://danube-webshop.herokuapp.com");
+;(async () => {
+  const browser = await chromium.launch()
+  const page = await browser.newPage()
+  await page.goto('https://danube-webshop.herokuapp.com')
   const content = await page.evaluate(() => {
-    let data = [];
+    const data = []
 
-    let books = document.querySelectorAll(".preview");
+    const books = document.querySelectorAll('.preview')
     books.forEach((book) => {
-      let title = book.querySelector(".preview-title").innerText;
-      let author = book.querySelector(".preview-author").innerText;
-      let price = book.querySelector(".preview-price").innerText;
+      const title = book.querySelector('.preview-title').innerText
+      const author = book.querySelector('.preview-author').innerText
+      const price = book.querySelector('.preview-price').innerText
       data.push({
         title,
         author,
-        price,
-      });
-    });
-    return data;
-  });
+        price
+      })
+    })
+    return data
+  })
 
-  const jsonData = JSON.stringify(content);
-  fs.writeFileSync("books.json", jsonData);
-  await browser.close();
-})();
-
+  const jsonData = JSON.stringify(content)
+  fs.writeFileSync('books.json', jsonData)
+  await browser.close()
+})()

--- a/site/content/samples/playwright/basic-get-href-handle.js
+++ b/site/content/samples/playwright/basic-get-href-handle.js
@@ -1,11 +1,11 @@
-const { chromium } = require("playwright");
+const { chromium } = require('playwright')
 
-(async () => {
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
-  await page.goto("https://danube-webshop.herokuapp.com");
-  const element = await page.$("a");
-  const href = await element.evaluate((node) => node.href);
-  console.log(href);
-  await browser.close();
-})();
+;(async () => {
+  const browser = await chromium.launch()
+  const page = await browser.newPage()
+  await page.goto('https://danube-webshop.herokuapp.com')
+  const element = await page.$('a')
+  const href = await element.evaluate((node) => node.href)
+  console.log(href)
+  await browser.close()
+})()

--- a/site/content/samples/playwright/basic-get-href-value.js
+++ b/site/content/samples/playwright/basic-get-href-value.js
@@ -1,10 +1,10 @@
-const { chromium } = require("playwright");
+const { chromium } = require('playwright')
 
-(async () => {
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
-  await page.goto("https://danube-webshop.herokuapp.com");
-  const url = await page.$eval("a", (el) => el.href);
-  console.log(url);
-  await browser.close();
-})();
+;(async () => {
+  const browser = await chromium.launch()
+  const page = await browser.newPage()
+  await page.goto('https://danube-webshop.herokuapp.com')
+  const url = await page.$eval('a', (el) => el.href)
+  console.log(url)
+  await browser.close()
+})()

--- a/site/content/samples/playwright/basic-get-image.js
+++ b/site/content/samples/playwright/basic-get-image.js
@@ -1,15 +1,15 @@
-const { chromium } = require("playwright");
-const axios = require("axios");
-const fs = require("fs");
+const { chromium } = require('playwright')
+const axios = require('axios')
+const fs = require('fs')
 
-(async () => {
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
-  await page.goto("https://danube-webshop.herokuapp.com");
-  const url = await page.$eval("img", (el) => el.src);
+;(async () => {
+  const browser = await chromium.launch()
+  const page = await browser.newPage()
+  await page.goto('https://danube-webshop.herokuapp.com')
+  const url = await page.$eval('img', (el) => el.src)
 
-  const response = await axios.get(url);
-  fs.writeFileSync("scraped-image.svg", response.data);
+  const response = await axios.get(url)
+  fs.writeFileSync('scraped-image.svg', response.data)
 
-  await browser.close();
-})();
+  await browser.close()
+})()

--- a/site/content/samples/playwright/basic-get-text-values.js
+++ b/site/content/samples/playwright/basic-get-text-values.js
@@ -1,12 +1,12 @@
-const { chromium } = require("playwright");
+const { chromium } = require('playwright')
 
-(async () => {
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
-  await page.goto("https://danube-webshop.herokuapp.com");
-  const categories = await page.$$eval("li a", (nodes) =>
+;(async () => {
+  const browser = await chromium.launch()
+  const page = await browser.newPage()
+  await page.goto('https://danube-webshop.herokuapp.com')
+  const categories = await page.$$eval('li a', (nodes) =>
     nodes.map((n) => n.innerText)
-  );
-  console.log(categories);
-  await browser.close();
-})();
+  )
+  console.log(categories)
+  await browser.close()
+})()

--- a/site/content/samples/playwright/basic-navigation.js
+++ b/site/content/samples/playwright/basic-navigation.js
@@ -1,6 +1,6 @@
-const { chromium } = require('playwright');
+const { chromium } = require('playwright')
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const page = await browser.newPage()
   await page.goto('https://danube-webshop.herokuapp.com')

--- a/site/content/samples/playwright/basic-performance-emulation.js
+++ b/site/content/samples/playwright/basic-performance-emulation.js
@@ -1,6 +1,6 @@
-const { chromium } = require('playwright');
+const { chromium } = require('playwright')
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const page = await browser.newPage()
 

--- a/site/content/samples/playwright/basic-performance-lighthouse.js
+++ b/site/content/samples/playwright/basic-performance-lighthouse.js
@@ -2,16 +2,22 @@ const chromeLauncher = require('chrome-launcher')
 const { chromium } = require('playwright')
 const lighthouse = require('lighthouse')
 const request = require('request')
-const util = require('util');
+const util = require('util')
 
-(async () => {
+;(async () => {
   const chrome = await chromeLauncher.launch()
 
-  const resp = await util.promisify(request)(`http://localhost:${chrome.port}/json/version`)
+  const resp = await util.promisify(request)(
+    `http://localhost:${chrome.port}/json/version`
+  )
   const { webSocketDebuggerUrl } = JSON.parse(resp.body)
   const browser = await chromium.connect({ wsEndpoint: webSocketDebuggerUrl })
 
-  const { lhr } = await lighthouse('https://danube-webshop.herokuapp.com', { port: chrome.port }, null)
+  const { lhr } = await lighthouse(
+    'https://danube-webshop.herokuapp.com',
+    { port: chrome.port },
+    null
+  )
 
   console.log('Report complete for', lhr.finalUrl)
 

--- a/site/content/samples/playwright/basic-performance-navigation.js
+++ b/site/content/samples/playwright/basic-performance-navigation.js
@@ -1,16 +1,19 @@
-const { chromium } = require('playwright');
+const { chromium } = require('playwright')
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const page = await browser.newPage()
   await page.goto('https://danube-webshop.herokuapp.com')
 
-  const performanceTimingJson = await page.evaluate(() => JSON.stringify(window.performance.timing))
+  const performanceTimingJson = await page.evaluate(() =>
+    JSON.stringify(window.performance.timing)
+  )
   const performanceTiming = JSON.parse(performanceTimingJson)
 
   console.log(performanceTiming)
 
-  const startToInteractive = performanceTiming.domInteractive - performanceTiming.navigationStart
+  const startToInteractive =
+    performanceTiming.domInteractive - performanceTiming.navigationStart
   console.log(`Navigation start to DOM interactive: ${startToInteractive}ms`)
 
   await browser.close()

--- a/site/content/samples/playwright/basic-performance-resource.js
+++ b/site/content/samples/playwright/basic-performance-resource.js
@@ -1,15 +1,18 @@
-const { chromium } = require('playwright');
+const { chromium } = require('playwright')
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const page = await browser.newPage()
   await page.goto('https://danube-webshop.herokuapp.com')
 
   const resourceTimingJson = await page.evaluate(() =>
-    JSON.stringify(window.performance.getEntriesByType('resource')))
+    JSON.stringify(window.performance.getEntriesByType('resource'))
+  )
 
   const resourceTiming = JSON.parse(resourceTimingJson)
-  const logoResourceTiming = resourceTiming.find(element => element.name.includes('.svg'))
+  const logoResourceTiming = resourceTiming.find((element) =>
+    element.name.includes('.svg')
+  )
 
   console.log(logoResourceTiming)
 

--- a/site/content/samples/playwright/basic-screenshot-clipped.js
+++ b/site/content/samples/playwright/basic-screenshot-clipped.js
@@ -9,9 +9,9 @@ const options = {
   }
 }
 
-const { chromium } = require('playwright');
+const { chromium } = require('playwright')
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const page = await browser.newPage()
   await page.setViewportSize({ width: 1280, height: 800 })

--- a/site/content/samples/playwright/basic-screenshot.js
+++ b/site/content/samples/playwright/basic-screenshot.js
@@ -1,6 +1,6 @@
-const { chromium } = require('playwright');
+const { chromium } = require('playwright')
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const page = await browser.newPage()
   await page.setViewportSize({ width: 1280, height: 800 })

--- a/site/content/samples/playwright/checkout.js
+++ b/site/content/samples/playwright/checkout.js
@@ -1,7 +1,7 @@
 const { chromium } = require('playwright')
-const productsNumber = process.env.PRODUCTS_NUMBER || 3;
+const productsNumber = process.env.PRODUCTS_NUMBER || 3
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const page = await browser.newPage()
 
@@ -9,7 +9,7 @@ const productsNumber = process.env.PRODUCTS_NUMBER || 3;
 
   await page.goto('https://danube-webshop.herokuapp.com/')
 
-  for (i = 1; i <= productsNumber; i++) {
+  for (let i = 1; i <= productsNumber; i++) {
     await page.click(`.preview:nth-child(${i}) > .preview-author`)
     await page.click('.detail-wrapper > .call-to-action')
     await page.click('#logo')

--- a/site/content/samples/playwright/cookies-reading.js
+++ b/site/content/samples/playwright/cookies-reading.js
@@ -1,7 +1,7 @@
 const { chromium } = require('playwright')
-const fs = require('fs');
+const fs = require('fs')
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const context = await browser.newContext()
 

--- a/site/content/samples/playwright/cookies-writing.js
+++ b/site/content/samples/playwright/cookies-writing.js
@@ -1,7 +1,7 @@
 const { chromium } = require('playwright')
-const fs = require('fs');
+const fs = require('fs')
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const context = await browser.newContext()
 

--- a/site/content/samples/playwright/coupon.js
+++ b/site/content/samples/playwright/coupon.js
@@ -1,32 +1,32 @@
-const assert = require("chai").assert;
-const { chromium } = require("playwright");
-const productsNumber = process.env.PRODUCTS_NUMBER || 3;
+const assert = require('chai').assert
+const { chromium } = require('playwright')
+const productsNumber = process.env.PRODUCTS_NUMBER || 3
 
-(async () => {
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
+;(async () => {
+  const browser = await chromium.launch()
+  const page = await browser.newPage()
 
-  await page.goto("https://danube-webshop.herokuapp.com/");
+  await page.goto('https://danube-webshop.herokuapp.com/')
 
-  for (i = 1; i <= productsNumber; i++) {
-    await page.click(`.preview:nth-child(${i}) > .preview-author`);
-    await page.click(".detail-wrapper > .call-to-action");
-    await page.click("#logo");
+  for (let i = 1; i <= productsNumber; i++) {
+    await page.click(`.preview:nth-child(${i}) > .preview-author`)
+    await page.click('.detail-wrapper > .call-to-action')
+    await page.click('#logo')
   }
 
-  await page.click("#cart");
+  await page.click('#cart')
 
-  await page.waitForSelector("#total-price");
-  const price = await page.$eval("#total-price", (e) => e.innerText);
+  await page.waitForSelector('#total-price')
+  const price = await page.$eval('#total-price', (e) => e.innerText)
 
-  await page.click(".cart > label");
-  await page.click("#coupon");
-  await page.type("#coupon", "COUPON2020");
-  await page.click(".cart > div > button");
+  await page.click('.cart > label')
+  await page.click('#coupon')
+  await page.type('#coupon', 'COUPON2020')
+  await page.click('.cart > div > button')
 
-  const expectedDiscountedPrice = price * 0.8;
-  const discountedPrice = await page.$eval("#total-price", (e) => e.innerText);
-  assert.equal(discountedPrice, expectedDiscountedPrice);
+  const expectedDiscountedPrice = price * 0.8
+  const discountedPrice = await page.$eval('#total-price', (e) => e.innerText)
+  assert.equal(discountedPrice, expectedDiscountedPrice)
 
-  await browser.close();
-})();
+  await browser.close()
+})()

--- a/site/content/samples/playwright/file-download-alt.js
+++ b/site/content/samples/playwright/file-download-alt.js
@@ -1,8 +1,8 @@
 const { chromium } = require('playwright')
 const fs = require('fs')
-const assert = require('chai').assert;
+const assert = require('chai').assert
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const context = await browser.newContext({ acceptDownloads: true })
   const page = await context.newPage()

--- a/site/content/samples/playwright/file-download.js
+++ b/site/content/samples/playwright/file-download.js
@@ -1,9 +1,9 @@
 const { chromium } = require('playwright')
 const axios = require('axios')
 const fs = require('fs')
-const assert = require('chai').assert;
+const assert = require('chai').assert
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const page = await browser.newPage()
 

--- a/site/content/samples/playwright/file-upload.js
+++ b/site/content/samples/playwright/file-upload.js
@@ -1,29 +1,29 @@
-const { chromium } = require("playwright");
+const { chromium } = require('playwright')
 
-(async () => {
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
+;(async () => {
+  const browser = await chromium.launch()
+  const page = await browser.newPage()
 
-  await page.goto("https://danube-webshop.herokuapp.com/");
+  await page.goto('https://danube-webshop.herokuapp.com/')
 
-  await page.click("#login");
-  await page.click("#n-email");
+  await page.click('#login')
+  await page.click('#n-email')
 
-  await page.type("#n-email", process.env.USER_EMAIL);
-  await page.type("#n-password2", process.env.USER_PASSWORD);
-  await page.click("#goto-signin-btn");
+  await page.type('#n-email', process.env.USER_EMAIL)
+  await page.type('#n-password2', process.env.USER_PASSWORD)
+  await page.click('#goto-signin-btn')
 
-  await page.click(".fa-user");
+  await page.click('.fa-user')
 
-  await page.waitForSelector("#user-details > div > input");
+  await page.waitForSelector('#user-details > div > input')
 
-  const handle = await page.$('input[type="file"]');
-  await handle.setInputFiles(process.env.FILE_PATH);
+  const handle = await page.$('input[type="file"]')
+  await handle.setInputFiles(process.env.FILE_PATH)
 
-  await page.waitForSelector("#user-details > div > button");
-  await page.click("#user-details > div > button");
+  await page.waitForSelector('#user-details > div > button')
+  await page.click('#user-details > div > button')
 
-  await page.waitForSelector("#upload-message-succcess", { visible: true });
+  await page.waitForSelector('#upload-message-succcess', { visible: true })
 
-  await browser.close();
-})();
+  await browser.close()
+})()

--- a/site/content/samples/playwright/google-login.js
+++ b/site/content/samples/playwright/google-login.js
@@ -1,18 +1,19 @@
-const { webkit } = require("playwright");
-(async () => {
-  const browser = await webkit.launch();
-  const page = await browser.newPage();
+const { webkit } = require('playwright')
 
-  await page.setViewport({ width: 1280, height: 800 });
-  await page.goto("https://stackoverflow.com/users/login");
+;(async () => {
+  const browser = await webkit.launch()
+  const page = await browser.newPage()
 
-  await page.click("button.s-btn__google");
+  await page.setViewport({ width: 1280, height: 800 })
+  await page.goto('https://stackoverflow.com/users/login')
 
-  await page.fill('input[type="email"]', process.env.GOOGLE_USER);
-  await page.click("#identifierNext");
+  await page.click('button.s-btn__google')
 
-  await page.fill('input[type="password"]', process.env.GOOGLE_PWD);
-  await page.click("#passwordNext");
+  await page.fill('input[type="email"]', process.env.GOOGLE_USER)
+  await page.click('#identifierNext')
 
-  await browser.close();
-})();
+  await page.fill('input[type="password"]', process.env.GOOGLE_PWD)
+  await page.click('#passwordNext')
+
+  await browser.close()
+})()

--- a/site/content/samples/playwright/localstorage-reading.js
+++ b/site/content/samples/playwright/localstorage-reading.js
@@ -1,19 +1,21 @@
-const {chromium} = require('playwright')
-const fs = require('fs');
+const { chromium } = require('playwright')
+const fs = require('fs')
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const page = await browser.newPage()
 
   await page.goto('https://danube-webshop.herokuapp.com')
 
-  for (i = 1; i <= 3; i++) {
-    await page.click(`.preview:nth-child(${i}) > .preview-author`);
-    await page.click(".detail-wrapper > .call-to-action");
-    await page.click("#logo");
+  for (let i = 1; i <= 3; i++) {
+    await page.click(`.preview:nth-child(${i}) > .preview-author`)
+    await page.click('.detail-wrapper > .call-to-action')
+    await page.click('#logo')
   }
 
-  const localStorage = await page.evaluate(() => JSON.stringify(window.localStorage));
+  const localStorage = await page.evaluate(() =>
+    JSON.stringify(window.localStorage)
+  )
   fs.writeFileSync('localstorage.json', localStorage)
 
   await browser.close()

--- a/site/content/samples/playwright/localstorage-writing.js
+++ b/site/content/samples/playwright/localstorage-writing.js
@@ -1,7 +1,7 @@
-const {chromium} = require('playwright')
-const fs = require('fs');
+const { chromium } = require('playwright')
+const fs = require('fs')
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const page = await browser.newPage()
 
@@ -10,14 +10,14 @@ const fs = require('fs');
   const localStorage = fs.readFileSync('localstorage.json', 'utf8')
 
   const deserializedStorage = JSON.parse(localStorage)
-  await page.evaluate(deserializedStorage => {
+  await page.evaluate((deserializedStorage) => {
     for (const key in deserializedStorage) {
-      localStorage.setItem(key, deserializedStorage[key]);
+      localStorage.setItem(key, deserializedStorage[key])
     }
-  }, deserializedStorage);
+  }, deserializedStorage)
 
-  await page.waitForSelector("#cart")
-  await page.click("#cart")
+  await page.waitForSelector('#cart')
+  await page.click('#cart')
 
   await browser.close()
 })()

--- a/site/content/samples/playwright/login.js
+++ b/site/content/samples/playwright/login.js
@@ -1,20 +1,20 @@
-const { chromium } = require("playwright");
+const { chromium } = require('playwright')
 
-(async () => {
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
+;(async () => {
+  const browser = await chromium.launch()
+  const page = await browser.newPage()
 
-  await page.goto("https://danube-webshop.herokuapp.com/");
+  await page.goto('https://danube-webshop.herokuapp.com/')
 
-  await page.click("#login");
+  await page.click('#login')
 
-  await page.type("#n-email", process.env.USER_EMAIL);
+  await page.type('#n-email', process.env.USER_EMAIL)
 
-  await page.type("#n-password2", process.env.USER_PASSWORD);
+  await page.type('#n-password2', process.env.USER_PASSWORD)
 
-  await page.click("#goto-signin-btn");
+  await page.click('#goto-signin-btn')
 
-  await page.waitForSelector("#login-message", { visible: true });
+  await page.waitForSelector('#login-message', { visible: true })
 
-  await browser.close();
-})();
+  await browser.close()
+})()

--- a/site/content/samples/playwright/mslive-login.js
+++ b/site/content/samples/playwright/mslive-login.js
@@ -1,17 +1,17 @@
-const { chromium } = require("playwright");
+const { chromium } = require('playwright')
 
-(async () => {
-  const browser = await chromium.launch({ headless: false });
-  const page = await browser.newPage();
+;(async () => {
+  const browser = await chromium.launch({ headless: false })
+  const page = await browser.newPage()
 
-  await page.setViewport({ width: 1280, height: 800 });
-  await page.goto("https://login.live.com/");
+  await page.setViewport({ width: 1280, height: 800 })
+  await page.goto('https://login.live.com/')
 
-  await page.fill('[name="loginfmt"]', process.env.MSLIVE_USER);
-  await page.click('[type="submit"]');
+  await page.fill('[name="loginfmt"]', process.env.MSLIVE_USER)
+  await page.click('[type="submit"]')
 
-  await page.fill('input[type="password"]', process.env.MSLIVE_PWD);
-  await page.keyboard.press("Enter");
+  await page.fill('input[type="password"]', process.env.MSLIVE_PWD)
+  await page.keyboard.press('Enter')
 
-  await browser.close();
-})();
+  await browser.close()
+})()

--- a/site/content/samples/playwright/multitab-flows.js
+++ b/site/content/samples/playwright/multitab-flows.js
@@ -1,5 +1,5 @@
-const { chromium } = require('playwright');
-(async () => {
+const { chromium } = require('playwright')
+;(async () => {
   const browser = await chromium.launch()
   const context = await browser.newContext()
   const page = await context.newPage()

--- a/site/content/samples/playwright/multitab-open.js
+++ b/site/content/samples/playwright/multitab-open.js
@@ -1,5 +1,5 @@
-const { chromium } = require('playwright');
-(async () => {
+const { chromium } = require('playwright')
+;(async () => {
   const browser = await chromium.launch()
   const context = await browser.newContext()
 

--- a/site/content/samples/playwright/pdf-hd.js
+++ b/site/content/samples/playwright/pdf-hd.js
@@ -1,7 +1,7 @@
 const { chromium } = require('playwright')
-const fs = require('fs');
+const fs = require('fs')
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const page = await browser.newPage()
 

--- a/site/content/samples/playwright/pdf-minimal.js
+++ b/site/content/samples/playwright/pdf-minimal.js
@@ -1,6 +1,6 @@
-const { chromium } = require('playwright');
+const { chromium } = require('playwright')
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const page = await browser.newPage()
   await page.goto('https://checklyhq.com/learn/headless')

--- a/site/content/samples/playwright/request-interception-block.js
+++ b/site/content/samples/playwright/request-interception-block.js
@@ -1,6 +1,6 @@
-const { chromium } = require('playwright');
+const { chromium } = require('playwright')
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const page = await browser.newPage()
 

--- a/site/content/samples/playwright/request-interception-read.js
+++ b/site/content/samples/playwright/request-interception-read.js
@@ -1,15 +1,17 @@
-const { chromium } = require('playwright');
+const { chromium } = require('playwright')
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const page = await browser.newPage()
 
   await page.setViewportSize({ width: 1200, height: 800 })
 
-  page.on('request', request =>
-    console.log('>>', request.method(), request.url()))
-  page.on('response', response =>
-    console.log('<<', response.status(), response.url()))
+  page.on('request', (request) =>
+    console.log('>>', request.method(), request.url())
+  )
+  page.on('response', (response) =>
+    console.log('<<', response.status(), response.url())
+  )
 
   await page.goto('https://danube-webshop.herokuapp.com/')
 

--- a/site/content/samples/playwright/response-interception.js
+++ b/site/content/samples/playwright/response-interception.js
@@ -10,9 +10,9 @@ const mockResponseObject = [
     rating: '★★★★★',
     stock: 65535
   }
-];
+]
 
-(async () => {
+;(async () => {
   const browser = await chromium.launch()
   const page = await browser.newPage()
 

--- a/site/content/samples/playwright/scraping-example-purchases.js
+++ b/site/content/samples/playwright/scraping-example-purchases.js
@@ -1,5 +1,5 @@
-const { chromium } = require('playwright');
-(async () => {
+const { chromium } = require('playwright')
+;(async () => {
   const currency = process.env.CURRENCY
   const amazonUrl = process.env.AMAZON_URL
   const amazonUser = process.env.AMAZON_USER
@@ -24,7 +24,9 @@ const { chromium } = require('playwright');
 
   await page.click('#nav-link-accountList > .nav-long-width')
 
-  await page.click('.ya-card__whole-card-link > .a-box > .a-box-inner > .a-row > .a-column > div')
+  await page.click(
+    '.ya-card__whole-card-link > .a-box > .a-box-inner > .a-row > .a-column > div'
+  )
 
   await page.click('#a-autoid-1-announce > .a-dropdown-prompt')
 
@@ -37,8 +39,8 @@ const { chromium } = require('playwright');
   const pages = await page.$$('.a-normal')
 
   for (const singlePage of pages) {
-    await page.waitForSelector('.a-last')
-    prices = await page.$$eval(
+    await singlePage.waitForSelector('.a-last')
+    prices = await singlePage.$$eval(
       '.a-column:nth-child(2) .a-color-secondary.value',
       (nodes) => nodes.map((n) => n.innerText)
     )
@@ -46,15 +48,18 @@ const { chromium } = require('playwright');
     filteredPrices = filteredPrices.concat(
       prices.filter((price) => price.includes(currency))
     )
-    await page.waitForSelector('li.a-last')
-    await page.click('li.a-last')
+    await singlePage.waitForSelector('li.a-last')
+    await singlePage.click('li.a-last')
   }
 
   const cleanPrices = filteredPrices.map((x) => {
     return x.replace(',', '.').replace(/[^\d.,-]/g, '')
   })
 
-  const totalExpense = cleanPrices.reduce((a, b) => parseFloat(a) + parseFloat(b), 0)
+  const totalExpense = cleanPrices.reduce(
+    (a, b) => parseFloat(a) + parseFloat(b),
+    0
+  )
   console.log(`Total expense for the year: ${currency} ${totalExpense}`)
 
   await browser.close()

--- a/site/content/samples/playwright/search.js
+++ b/site/content/samples/playwright/search.js
@@ -1,44 +1,44 @@
-const { chromium } = require("playwright");
-const assert = require("chai").assert;
+const { chromium } = require('playwright')
+const assert = require('chai').assert
 
-(async () => {
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
+;(async () => {
+  const browser = await chromium.launch()
+  const page = await browser.newPage()
 
   const bookList = [
-    "The Foreigner",
-    "The Transformation",
-    "For Whom the Ball Tells",
-    "Baiting for Robot",
-  ];
+    'The Foreigner',
+    'The Transformation',
+    'For Whom the Ball Tells',
+    'Baiting for Robot'
+  ]
 
-  await page.goto("https://danube-webshop.herokuapp.com/");
+  await page.goto('https://danube-webshop.herokuapp.com/')
 
-  await page.click(".topbar > input");
-  await page.type(".topbar > input", "for");
-  await page.click("#button-search");
+  await page.click('.topbar > input')
+  await page.type('.topbar > input', 'for')
+  await page.click('#button-search')
 
   await page.waitForSelector(
-    ".shop-content > ul > .preview:nth-child(1) > .preview-title"
-  );
+    '.shop-content > ul > .preview:nth-child(1) > .preview-title'
+  )
 
   // Halt immediately if results do not equal expected number
-  let resultsNumber = (await page.$$(".preview-title")).length;
-  assert.equal(resultsNumber, bookList.length);
+  const resultsNumber = (await page.$$('.preview-title')).length
+  assert.equal(resultsNumber, bookList.length)
 
   // Remove every element found from the original array...
-  for (i = 0; i < resultsNumber; i++) {
+  for (let i = 0; i < resultsNumber; i++) {
     const resultTitle = await page.$eval(
       `.preview:nth-child(${i + 1}) > .preview-title`,
       (e) => e.innerText
-    );
+    )
 
-    const index = bookList.indexOf(resultTitle);
-    bookList.splice(index, 1);
+    const index = bookList.indexOf(resultTitle)
+    bookList.splice(index, 1)
   }
 
   // ...then assert that the original array is now empty
-  assert.equal(bookList.length, 0);
+  assert.equal(bookList.length, 0)
 
-  await browser.close();
-})();
+  await browser.close()
+})()

--- a/site/content/samples/playwright/signup.js
+++ b/site/content/samples/playwright/signup.js
@@ -1,26 +1,26 @@
-const { chromium } = require("playwright");
+const { chromium } = require('playwright')
 
-(async () => {
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
+;(async () => {
+  const browser = await chromium.launch()
+  const page = await browser.newPage()
 
-  await page.goto("https://danube-webshop.herokuapp.com/");
+  await page.goto('https://danube-webshop.herokuapp.com/')
 
-  await page.click("#signup");
-  await page.click("#s-name");
+  await page.click('#signup')
+  await page.click('#s-name')
 
-  await page.type("#s-name", "John");
-  await page.type("#s-surname", "Doe");
-  await page.type("#s-email", process.env.USER_EMAIL);
-  await page.type("#s-password2", process.env.USER_PASSWORD);
-  await page.type("#s-company", "John Doe Inc.");
+  await page.type('#s-name', 'John')
+  await page.type('#s-surname', 'Doe')
+  await page.type('#s-email', process.env.USER_EMAIL)
+  await page.type('#s-password2', process.env.USER_PASSWORD)
+  await page.type('#s-company', 'John Doe Inc.')
 
-  await page.click("#business");
-  await page.click("#marketing-agreement");
-  await page.click("#privacy-policy");
-  await page.click("#register-btn");
+  await page.click('#business')
+  await page.click('#marketing-agreement')
+  await page.click('#privacy-policy')
+  await page.click('#register-btn')
 
-  await page.waitForSelector("#login-message", { visible: true });
+  await page.waitForSelector('#login-message', { visible: true })
 
-  await browser.close();
-})();
+  await browser.close()
+})()

--- a/site/content/samples/puppeteer/basic-browser-navigation.js
+++ b/site/content/samples/puppeteer/basic-browser-navigation.js
@@ -1,6 +1,6 @@
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer')
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
   await page.goto('https://danube-webshop.herokuapp.com')

--- a/site/content/samples/puppeteer/basic-browser-waiting.js
+++ b/site/content/samples/puppeteer/basic-browser-waiting.js
@@ -1,6 +1,6 @@
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer')
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
   await page.goto('https://danube-store.herokuapp.com/')

--- a/site/content/samples/puppeteer/basic-click-type.js
+++ b/site/content/samples/puppeteer/basic-click-type.js
@@ -1,15 +1,15 @@
-const puppeteer = require("puppeteer");
+const puppeteer = require('puppeteer')
 
-(async () => {
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
-  await page.goto("https://danube-webshop.herokuapp.com/");
+;(async () => {
+  const browser = await puppeteer.launch()
+  const page = await browser.newPage()
+  await page.goto('https://danube-webshop.herokuapp.com/')
 
-  await page.waitForSelector("input");
-  await page.type("input", "some search terms");
+  await page.waitForSelector('input')
+  await page.type('input', 'some search terms')
 
-  await page.waitForSelector("button");
-  await page.click("button");
+  await page.waitForSelector('button')
+  await page.click('button')
 
-  await browser.close();
-})();
+  await browser.close()
+})()

--- a/site/content/samples/puppeteer/basic-get-data-json.js
+++ b/site/content/samples/puppeteer/basic-get-data-json.js
@@ -1,28 +1,28 @@
-const puppeteer = require("puppeteer");
-const fs = require("fs");
+const puppeteer = require('puppeteer')
+const fs = require('fs')
 
-(async () => {
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
-  await page.goto("https://danube-webshop.herokuapp.com");
+;(async () => {
+  const browser = await puppeteer.launch()
+  const page = await browser.newPage()
+  await page.goto('https://danube-webshop.herokuapp.com')
   const content = await page.evaluate(() => {
-    let data = [];
+    const data = []
 
-    let books = document.querySelectorAll(".preview");
+    const books = document.querySelectorAll('.preview')
     books.forEach((book) => {
-      let title = book.querySelector(".preview-title").innerText;
-      let author = book.querySelector(".preview-author").innerText;
-      let price = book.querySelector(".preview-price").innerText;
+      const title = book.querySelector('.preview-title').innerText
+      const author = book.querySelector('.preview-author').innerText
+      const price = book.querySelector('.preview-price').innerText
       data.push({
         title,
         author,
-        price,
-      });
-    });
-    return data;
-  });
+        price
+      })
+    })
+    return data
+  })
 
-  const jsonData = JSON.stringify(content);
-  fs.writeFileSync("books.json", jsonData);
-  await browser.close();
-})();
+  const jsonData = JSON.stringify(content)
+  fs.writeFileSync('books.json', jsonData)
+  await browser.close()
+})()

--- a/site/content/samples/puppeteer/basic-get-href-handle.js
+++ b/site/content/samples/puppeteer/basic-get-href-handle.js
@@ -1,11 +1,11 @@
-const puppeteer = require("puppeteer");
+const puppeteer = require('puppeteer')
 
-(async () => {
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
-  await page.goto("https://danube-webshop.herokuapp.com");
-  const element = await page.$("a");
-  const href = await element.evaluate((node) => node.href);
-  console.log(href);
-  await browser.close();
-})();
+;(async () => {
+  const browser = await puppeteer.launch()
+  const page = await browser.newPage()
+  await page.goto('https://danube-webshop.herokuapp.com')
+  const element = await page.$('a')
+  const href = await element.evaluate((node) => node.href)
+  console.log(href)
+  await browser.close()
+})()

--- a/site/content/samples/puppeteer/basic-get-href-value.js
+++ b/site/content/samples/puppeteer/basic-get-href-value.js
@@ -1,10 +1,10 @@
-const puppeteer = require("puppeteer");
+const puppeteer = require('puppeteer')
 
-(async () => {
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
-  await page.goto("https://danube-webshop.herokuapp.com");
-  const url = await page.$eval("a", (el) => el.href);
-  console.log(url);
-  await browser.close();
-})();
+;(async () => {
+  const browser = await puppeteer.launch()
+  const page = await browser.newPage()
+  await page.goto('https://danube-webshop.herokuapp.com')
+  const url = await page.$eval('a', (el) => el.href)
+  console.log(url)
+  await browser.close()
+})()

--- a/site/content/samples/puppeteer/basic-get-image.js
+++ b/site/content/samples/puppeteer/basic-get-image.js
@@ -1,15 +1,15 @@
-const puppeteer = require("puppeteer");
-const axios = require("axios");
-const fs = require("fs");
+const puppeteer = require('puppeteer')
+const axios = require('axios')
+const fs = require('fs')
 
-(async () => {
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
-  await page.goto("https://danube-webshop.herokuapp.com");
-  const url = await page.$eval("img", (el) => el.src);
+;(async () => {
+  const browser = await puppeteer.launch()
+  const page = await browser.newPage()
+  await page.goto('https://danube-webshop.herokuapp.com')
+  const url = await page.$eval('img', (el) => el.src)
 
-  const response = await axios.get(url);
-  fs.writeFileSync("scraped-image.svg", response.data);
+  const response = await axios.get(url)
+  fs.writeFileSync('scraped-image.svg', response.data)
 
-  await browser.close();
-})();
+  await browser.close()
+})()

--- a/site/content/samples/puppeteer/basic-get-text-values.js
+++ b/site/content/samples/puppeteer/basic-get-text-values.js
@@ -1,12 +1,12 @@
-const puppeteer = require("puppeteer");
+const puppeteer = require('puppeteer')
 
-(async () => {
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
-  await page.goto("https://danube-webshop.herokuapp.com");
-  const categories = await page.$$eval("li a", (nodes) =>
+;(async () => {
+  const browser = await puppeteer.launch()
+  const page = await browser.newPage()
+  await page.goto('https://danube-webshop.herokuapp.com')
+  const categories = await page.$$eval('li a', (nodes) =>
     nodes.map((n) => n.innerText)
-  );
-  console.log(categories);
-  await browser.close();
-})();
+  )
+  console.log(categories)
+  await browser.close()
+})()

--- a/site/content/samples/puppeteer/basic-navigation.js
+++ b/site/content/samples/puppeteer/basic-navigation.js
@@ -1,6 +1,6 @@
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer')
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
   await page.goto('https://danube-webshop.herokuapp.com')

--- a/site/content/samples/puppeteer/basic-performance-emulation.js
+++ b/site/content/samples/puppeteer/basic-performance-emulation.js
@@ -1,6 +1,6 @@
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer')
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
 

--- a/site/content/samples/puppeteer/basic-performance-lighthouse.js
+++ b/site/content/samples/puppeteer/basic-performance-lighthouse.js
@@ -2,16 +2,24 @@ const chromeLauncher = require('chrome-launcher')
 const puppeteer = require('puppeteer')
 const lighthouse = require('lighthouse')
 const request = require('request')
-const util = require('util');
+const util = require('util')
 
-(async () => {
+;(async () => {
   const chrome = await chromeLauncher.launch()
 
-  const resp = await util.promisify(request)(`http://localhost:${chrome.port}/json/version`)
+  const resp = await util.promisify(request)(
+    `http://localhost:${chrome.port}/json/version`
+  )
   const { webSocketDebuggerUrl } = JSON.parse(resp.body)
-  const browser = await puppeteer.connect({ browserWSEndpoint: webSocketDebuggerUrl })
+  const browser = await puppeteer.connect({
+    browserWSEndpoint: webSocketDebuggerUrl
+  })
 
-  const { lhr } = await lighthouse('https://danube-webshop.herokuapp.com', { port: chrome.port }, null)
+  const { lhr } = await lighthouse(
+    'https://danube-webshop.herokuapp.com',
+    { port: chrome.port },
+    null
+  )
 
   console.log('Report complete for', lhr.finalUrl)
 

--- a/site/content/samples/puppeteer/basic-performance-navigation.js
+++ b/site/content/samples/puppeteer/basic-performance-navigation.js
@@ -1,16 +1,19 @@
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer')
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
   await page.goto('https://danube-webshop.herokuapp.com')
 
-  const performanceTimingJson = await page.evaluate(() => JSON.stringify(window.performance.timing))
+  const performanceTimingJson = await page.evaluate(() =>
+    JSON.stringify(window.performance.timing)
+  )
   const performanceTiming = JSON.parse(performanceTimingJson)
 
   console.log(performanceTiming)
 
-  const startToInteractive = performanceTiming.domInteractive - performanceTiming.navigationStart
+  const startToInteractive =
+    performanceTiming.domInteractive - performanceTiming.navigationStart
   console.log(`Navigation start to DOM interactive: ${startToInteractive}ms`)
 
   await browser.close()

--- a/site/content/samples/puppeteer/basic-performance-resource.js
+++ b/site/content/samples/puppeteer/basic-performance-resource.js
@@ -1,15 +1,18 @@
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer')
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
   await page.goto('https://danube-webshop.herokuapp.com')
 
   const resourceTimingJson = await page.evaluate(() =>
-    JSON.stringify(window.performance.getEntriesByType('resource')))
+    JSON.stringify(window.performance.getEntriesByType('resource'))
+  )
 
   const resourceTiming = JSON.parse(resourceTimingJson)
-  const logoResourceTiming = resourceTiming.find(element => element.name.includes('.svg'))
+  const logoResourceTiming = resourceTiming.find((element) =>
+    element.name.includes('.svg')
+  )
 
   console.log(logoResourceTiming)
 

--- a/site/content/samples/puppeteer/basic-screenshot-clipped.js
+++ b/site/content/samples/puppeteer/basic-screenshot-clipped.js
@@ -9,9 +9,9 @@ const options = {
   }
 }
 
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer')
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
   await page.setViewport({ width: 1280, height: 800 })

--- a/site/content/samples/puppeteer/basic-screenshot.js
+++ b/site/content/samples/puppeteer/basic-screenshot.js
@@ -1,6 +1,6 @@
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer')
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
   await page.setViewport({ width: 1280, height: 800 })

--- a/site/content/samples/puppeteer/checkout.js
+++ b/site/content/samples/puppeteer/checkout.js
@@ -1,56 +1,56 @@
-const puppeteer = require("puppeteer");
-const productsNumber = process.env.PRODUCTS_NUMBER || 3;
+const puppeteer = require('puppeteer')
+const productsNumber = process.env.PRODUCTS_NUMBER || 3
 
-(async () => {
-  const browser = await puppeteer.launch();
+;(async () => {
+  const browser = await puppeteer.launch()
 
-  const page = await browser.newPage();
+  const page = await browser.newPage()
 
-  const navigationPromise = page.waitForNavigation();
+  const navigationPromise = page.waitForNavigation()
 
-  await page.goto("https://danube-webshop.herokuapp.com/");
+  await page.goto('https://danube-webshop.herokuapp.com/')
 
-  await page.setViewport({ width: 1200, height: 800 });
+  await page.setViewport({ width: 1200, height: 800 })
 
-  for (i = 1; i <= productsNumber; i++) {
-    await page.waitForSelector(`.preview:nth-child(${i}) > .preview-author`);
-    await page.click(`.preview:nth-child(${i}) > .preview-author`);
+  for (let i = 1; i <= productsNumber; i++) {
+    await page.waitForSelector(`.preview:nth-child(${i}) > .preview-author`)
+    await page.click(`.preview:nth-child(${i}) > .preview-author`)
 
-    await page.waitForSelector(".detail-wrapper > .call-to-action");
-    await page.click(".detail-wrapper > .call-to-action");
+    await page.waitForSelector('.detail-wrapper > .call-to-action')
+    await page.click('.detail-wrapper > .call-to-action')
 
-    await page.waitForSelector("#logo");
-    await page.click("#logo");
+    await page.waitForSelector('#logo')
+    await page.click('#logo')
 
-    await navigationPromise;
+    await navigationPromise
   }
 
-  await page.waitForSelector("#cart");
-  await page.click("#cart");
+  await page.waitForSelector('#cart')
+  await page.click('#cart')
 
-  await page.waitForSelector(".cart > .call-to-action");
-  await page.click(".cart > .call-to-action");
+  await page.waitForSelector('.cart > .call-to-action')
+  await page.click('.cart > .call-to-action')
 
-  await page.waitForSelector("#s-name");
-  await page.click("#s-name");
+  await page.waitForSelector('#s-name')
+  await page.click('#s-name')
 
-  await page.type("#s-name", "Max");
-  await page.type("#s-surname", "Mustermann");
-  await page.type("#s-address", "Charlottenstr. 57");
-  await page.type("#s-zipcode", "10117");
-  await page.type("#s-city", "Berlin");
-  await page.type("#s-company", "Firma GmbH");
+  await page.type('#s-name', 'Max')
+  await page.type('#s-surname', 'Mustermann')
+  await page.type('#s-address', 'Charlottenstr. 57')
+  await page.type('#s-zipcode', '10117')
+  await page.type('#s-city', 'Berlin')
+  await page.type('#s-company', 'Firma GmbH')
 
-  await page.waitForSelector(".checkout > form");
-  await page.click(".checkout > form");
+  await page.waitForSelector('.checkout > form')
+  await page.click('.checkout > form')
 
-  await page.waitForSelector("#asap");
-  await page.click("#asap");
+  await page.waitForSelector('#asap')
+  await page.click('#asap')
 
-  await page.waitForSelector(".checkout > .call-to-action");
-  await page.click(".checkout > .call-to-action");
+  await page.waitForSelector('.checkout > .call-to-action')
+  await page.click('.checkout > .call-to-action')
 
-  await page.waitForSelector("#order-confirmation", { visible: true });
+  await page.waitForSelector('#order-confirmation', { visible: true })
 
-  await browser.close();
-})();
+  await browser.close()
+})()

--- a/site/content/samples/puppeteer/cookies-reading.js
+++ b/site/content/samples/puppeteer/cookies-reading.js
@@ -1,7 +1,7 @@
 const puppeteer = require('puppeteer')
-const fs = require('fs');
+const fs = require('fs')
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
 

--- a/site/content/samples/puppeteer/cookies-writing.js
+++ b/site/content/samples/puppeteer/cookies-writing.js
@@ -1,7 +1,7 @@
 const puppeteer = require('puppeteer')
-const fs = require('fs');
+const fs = require('fs')
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
 

--- a/site/content/samples/puppeteer/coupon.js
+++ b/site/content/samples/puppeteer/coupon.js
@@ -1,45 +1,45 @@
-const puppeteer = require("puppeteer");
-const assert = require("chai").assert;
-const productsNumber = process.env.PRODUCTS_NUMBER || 3;
+const puppeteer = require('puppeteer')
+const assert = require('chai').assert
+const productsNumber = process.env.PRODUCTS_NUMBER || 3
 
-(async () => {
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
+;(async () => {
+  const browser = await puppeteer.launch()
+  const page = await browser.newPage()
 
-  await page.goto("https://danube-webshop.herokuapp.com/");
+  await page.goto('https://danube-webshop.herokuapp.com/')
 
-  await page.setViewport({ width: 1792, height: 925 });
+  await page.setViewport({ width: 1792, height: 925 })
 
-  for (i = 1; i <= productsNumber; i++) {
+  for (let i = 1; i <= productsNumber; i++) {
     await page.waitForSelector(
-      ".preview:nth-child(1) > .preview-details > p:nth-child(1)"
-    );
-    await page.click(`.preview:nth-child(${i}) > .preview-author`);
-    await page.waitForSelector(".detail-wrapper > .call-to-action");
-    await page.click(".detail-wrapper > .call-to-action");
-    await page.waitForSelector("#logo");
-    await page.click("#logo");
+      '.preview:nth-child(1) > .preview-details > p:nth-child(1)'
+    )
+    await page.click(`.preview:nth-child(${i}) > .preview-author`)
+    await page.waitForSelector('.detail-wrapper > .call-to-action')
+    await page.click('.detail-wrapper > .call-to-action')
+    await page.waitForSelector('#logo')
+    await page.click('#logo')
   }
 
-  await page.waitForSelector("#cart");
-  await page.click("#cart");
+  await page.waitForSelector('#cart')
+  await page.click('#cart')
 
-  const price = await page.$eval("#total-price", (e) => e.innerText);
+  const price = await page.$eval('#total-price', (e) => e.innerText)
 
-  await page.waitForSelector(".cart > label");
-  await page.click(".cart > label");
+  await page.waitForSelector('.cart > label')
+  await page.click('.cart > label')
 
-  await page.waitForSelector("#coupon");
-  await page.click("#coupon");
+  await page.waitForSelector('#coupon')
+  await page.click('#coupon')
 
-  await page.type("#coupon", "COUPON2020");
+  await page.type('#coupon', 'COUPON2020')
 
-  await page.waitForSelector(".cart > div > button");
-  await page.click(".cart > div > button");
+  await page.waitForSelector('.cart > div > button')
+  await page.click('.cart > div > button')
 
-  const expectedDiscountedPrice = price * 0.8;
-  const discountedPrice = await page.$eval("#total-price", (e) => e.innerText);
-  assert.equal(discountedPrice, expectedDiscountedPrice);
+  const expectedDiscountedPrice = price * 0.8
+  const discountedPrice = await page.$eval('#total-price', (e) => e.innerText)
+  assert.equal(discountedPrice, expectedDiscountedPrice)
 
-  await browser.close();
-})();
+  await browser.close()
+})()

--- a/site/content/samples/puppeteer/file-download.js
+++ b/site/content/samples/puppeteer/file-download.js
@@ -1,9 +1,9 @@
 const puppeteer = require('puppeteer')
 const axios = require('axios')
 const fs = require('fs')
-const assert = require('chai').assert;
+const assert = require('chai').assert
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
 

--- a/site/content/samples/puppeteer/file-upload.js
+++ b/site/content/samples/puppeteer/file-upload.js
@@ -1,35 +1,35 @@
-const puppeteer = require("puppeteer");
+const puppeteer = require('puppeteer')
 
-(async () => {
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
+;(async () => {
+  const browser = await puppeteer.launch()
+  const page = await browser.newPage()
 
-  await page.goto("https://danube-webshop.herokuapp.com/");
+  await page.goto('https://danube-webshop.herokuapp.com/')
 
-  await page.setViewport({ width: 1200, height: 800 });
+  await page.setViewport({ width: 1200, height: 800 })
 
-  await page.waitForSelector("#login");
-  await page.click("#login");
+  await page.waitForSelector('#login')
+  await page.click('#login')
 
-  await page.waitForSelector("#n-email");
+  await page.waitForSelector('#n-email')
 
-  await page.type("#n-email", process.env.USER_EMAIL);
-  await page.type("#n-password2", process.env.USER_PASSWORD);
+  await page.type('#n-email', process.env.USER_EMAIL)
+  await page.type('#n-password2', process.env.USER_PASSWORD)
 
-  await page.waitForSelector("#goto-signin-btn");
-  await page.click("#goto-signin-btn");
+  await page.waitForSelector('#goto-signin-btn')
+  await page.click('#goto-signin-btn')
 
-  page.$eval(".fa-user", (elem) => elem.click());
+  page.$eval('.fa-user', (elem) => elem.click())
 
-  await page.waitForSelector("#user-details > div > input");
-  const inputUploadHandle = await page.$("#user-details > div > input");
-  let fileToUpload = process.env.FILE_PATH;
-  inputUploadHandle.uploadFile(fileToUpload);
+  await page.waitForSelector('#user-details > div > input')
+  const inputUploadHandle = await page.$('#user-details > div > input')
+  const fileToUpload = process.env.FILE_PATH
+  inputUploadHandle.uploadFile(fileToUpload)
 
-  await page.waitForSelector("#user-details > div > button");
-  await page.click("#user-details > div > button");
+  await page.waitForSelector('#user-details > div > button')
+  await page.click('#user-details > div > button')
 
-  await page.waitForSelector("#upload-message-succcess", { visible: true });
+  await page.waitForSelector('#upload-message-succcess', { visible: true })
 
-  await browser.close();
-})();
+  await browser.close()
+})()

--- a/site/content/samples/puppeteer/google-login.js
+++ b/site/content/samples/puppeteer/google-login.js
@@ -1,28 +1,28 @@
-const puppeteer = require("puppeteer");
+const puppeteer = require('puppeteer')
 
-(async () => {
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
+;(async () => {
+  const browser = await puppeteer.launch()
+  const page = await browser.newPage()
 
-  await page.setViewport({ width: 1280, height: 800 });
-  await page.goto("https://stackoverflow.com/users/login");
+  await page.setViewport({ width: 1280, height: 800 })
+  await page.goto('https://stackoverflow.com/users/login')
 
-  const navigationPromise = page.waitForNavigation();
+  const navigationPromise = page.waitForNavigation()
 
-  await page.waitForSelector("button.s-btn__google");
-  await page.click("button.s-btn__google");
+  await page.waitForSelector('button.s-btn__google')
+  await page.click('button.s-btn__google')
 
-  await navigationPromise;
-  await page.waitForSelector('input[type="email"]');
-  await page.type('input[type="email"]', process.env.GOOGLE_USER);
-  await page.click("#identifierNext");
+  await navigationPromise
+  await page.waitForSelector('input[type="email"]')
+  await page.type('input[type="email"]', process.env.GOOGLE_USER)
+  await page.click('#identifierNext')
 
-  await page.waitForSelector('input[type="password"]', { visible: true });
-  await page.type('input[type="password"]', process.env.GOOGLE_PWD);
+  await page.waitForSelector('input[type="password"]', { visible: true })
+  await page.type('input[type="password"]', process.env.GOOGLE_PWD)
 
-  await page.waitForSelector("#passwordNext", { visible: true });
-  await page.click("#passwordNext");
+  await page.waitForSelector('#passwordNext', { visible: true })
+  await page.click('#passwordNext')
 
-  await navigationPromise;
-  await browser.close();
-})();
+  await navigationPromise
+  await browser.close()
+})()

--- a/site/content/samples/puppeteer/localstorage-reading.js
+++ b/site/content/samples/puppeteer/localstorage-reading.js
@@ -1,24 +1,26 @@
 const puppeteer = require('puppeteer')
-const fs = require('fs');
+const fs = require('fs')
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
 
   await page.goto('https://danube-webshop.herokuapp.com')
 
-  for (i = 1; i <= 3; i++) {
-    await page.waitForSelector(`.preview:nth-child(${i}) > .preview-author`);
-    await page.click(`.preview:nth-child(${i}) > .preview-author`);
+  for (let i = 1; i <= 3; i++) {
+    await page.waitForSelector(`.preview:nth-child(${i}) > .preview-author`)
+    await page.click(`.preview:nth-child(${i}) > .preview-author`)
 
-    await page.waitForSelector(".detail-wrapper > .call-to-action");
-    await page.click(".detail-wrapper > .call-to-action");
+    await page.waitForSelector('.detail-wrapper > .call-to-action')
+    await page.click('.detail-wrapper > .call-to-action')
 
-    await page.waitForSelector("#logo");
-    await page.click("#logo");
+    await page.waitForSelector('#logo')
+    await page.click('#logo')
   }
 
-  const localStorage = await page.evaluate(() => JSON.stringify(window.localStorage));
+  const localStorage = await page.evaluate(() =>
+    JSON.stringify(window.localStorage)
+  )
   fs.writeFileSync('localstorage.json', localStorage)
 
   await browser.close()

--- a/site/content/samples/puppeteer/localstorage-writing.js
+++ b/site/content/samples/puppeteer/localstorage-writing.js
@@ -1,7 +1,7 @@
 const puppeteer = require('puppeteer')
-const fs = require('fs');
+const fs = require('fs')
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
 
@@ -10,14 +10,14 @@ const fs = require('fs');
   const localStorage = fs.readFileSync('localstorage.json', 'utf8')
 
   const deserializedStorage = JSON.parse(localStorage)
-  await page.evaluate(deserializedStorage => {
+  await page.evaluate((deserializedStorage) => {
     for (const key in deserializedStorage) {
-      localStorage.setItem(key, deserializedStorage[key]);
+      localStorage.setItem(key, deserializedStorage[key])
     }
-  }, deserializedStorage);
+  }, deserializedStorage)
 
-  await page.waitForSelector("#cart");
-  await page.click("#cart");
+  await page.waitForSelector('#cart')
+  await page.click('#cart')
 
   await browser.close()
 })()

--- a/site/content/samples/puppeteer/login.js
+++ b/site/content/samples/puppeteer/login.js
@@ -1,25 +1,25 @@
-const puppeteer = require("puppeteer");
+const puppeteer = require('puppeteer')
 
-(async () => {
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
+;(async () => {
+  const browser = await puppeteer.launch()
+  const page = await browser.newPage()
 
-  await page.setViewport({ width: 1280, height: 800 });
-  await page.goto("https://danube-webshop.herokuapp.com/");
+  await page.setViewport({ width: 1280, height: 800 })
+  await page.goto('https://danube-webshop.herokuapp.com/')
 
-  await page.waitForSelector("#login");
-  await page.click("#login");
+  await page.waitForSelector('#login')
+  await page.click('#login')
 
-  await page.waitForSelector("#n-email");
-  await page.type("#n-email", process.env.USER_EMAIL);
+  await page.waitForSelector('#n-email')
+  await page.type('#n-email', process.env.USER_EMAIL)
 
-  await page.waitForSelector("#n-password2");
-  await page.type("#n-password2", process.env.USER_PASSWORD);
+  await page.waitForSelector('#n-password2')
+  await page.type('#n-password2', process.env.USER_PASSWORD)
 
-  await page.waitForSelector("#goto-signin-btn");
-  await page.click("#goto-signin-btn");
+  await page.waitForSelector('#goto-signin-btn')
+  await page.click('#goto-signin-btn')
 
-  await page.waitForSelector("#login-message", { visible: true });
+  await page.waitForSelector('#login-message', { visible: true })
 
-  await browser.close();
-})();
+  await browser.close()
+})()

--- a/site/content/samples/puppeteer/mslive-login.js
+++ b/site/content/samples/puppeteer/mslive-login.js
@@ -1,23 +1,23 @@
-const puppeteer = require("puppeteer");
+const puppeteer = require('puppeteer')
 
-(async () => {
-  const browser = await puppeteer.launch({ headless: false });
-  const page = await browser.newPage();
+;(async () => {
+  const browser = await puppeteer.launch({ headless: false })
+  const page = await browser.newPage()
 
-  await page.setViewport({ width: 1280, height: 800 });
-  await page.goto("https://login.live.com/");
+  await page.setViewport({ width: 1280, height: 800 })
+  await page.goto('https://login.live.com/')
 
-  const navigationPromise = page.waitForNavigation();
+  const navigationPromise = page.waitForNavigation()
 
-  await page.waitForSelector('[name="loginfmt"]');
-  await page.type('[name="loginfmt"]', process.env.MSLIVE_USER);
-  await page.click('[type="submit"]');
+  await page.waitForSelector('[name="loginfmt"]')
+  await page.type('[name="loginfmt"]', process.env.MSLIVE_USER)
+  await page.click('[type="submit"]')
 
-  await navigationPromise;
-  await page.waitForSelector('input[type="password"]', { visible: true });
-  await page.type('input[type="password"]', process.env.MSLIVE_PWD);
-  await page.keyboard.press("Enter");
+  await navigationPromise
+  await page.waitForSelector('input[type="password"]', { visible: true })
+  await page.type('input[type="password"]', process.env.MSLIVE_PWD)
+  await page.keyboard.press('Enter')
 
-  await navigationPromise;
-  await browser.close();
-})();
+  await navigationPromise
+  await browser.close()
+})()

--- a/site/content/samples/puppeteer/multitab-flows.js
+++ b/site/content/samples/puppeteer/multitab-flows.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-(async () => {
+const puppeteer = require('puppeteer')
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
 
@@ -14,7 +14,9 @@ const puppeteer = require('puppeteer');
 
   await page.screenshot({ path: 'screenshot-tab-old.png' })
 
-  const newTarget = await browser.waitForTarget(target => target.opener() === pageTarget)
+  const newTarget = await browser.waitForTarget(
+    (target) => target.opener() === pageTarget
+  )
 
   const newPage = await newTarget.page()
 

--- a/site/content/samples/puppeteer/multitab-headful.js
+++ b/site/content/samples/puppeteer/multitab-headful.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-(async () => {
+const puppeteer = require('puppeteer')
+;(async () => {
   const browser = await puppeteer.launch({ headless: false })
   const page = await browser.newPage()
 
@@ -14,7 +14,9 @@ const puppeteer = require('puppeteer');
 
   await page.screenshot({ path: 'screenshot-tab-old.png' })
 
-  const newTarget = await browser.waitForTarget(target => target.opener() === pageTarget)
+  const newTarget = await browser.waitForTarget(
+    (target) => target.opener() === pageTarget
+  )
 
   const newPage = await newTarget.page()
   await newPage.bringToFront()

--- a/site/content/samples/puppeteer/multitab-open.js
+++ b/site/content/samples/puppeteer/multitab-open.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-(async () => {
+const puppeteer = require('puppeteer')
+;(async () => {
   const browser = await puppeteer.launch()
 
   const pageOne = await browser.newPage()

--- a/site/content/samples/puppeteer/pdf-hd.js
+++ b/site/content/samples/puppeteer/pdf-hd.js
@@ -1,7 +1,7 @@
 const puppeteer = require('puppeteer')
-const fs = require('fs');
+const fs = require('fs')
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
 

--- a/site/content/samples/puppeteer/pdf-minimal.js
+++ b/site/content/samples/puppeteer/pdf-minimal.js
@@ -1,6 +1,6 @@
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer')
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
   await page.goto('https://checklyhq.com/learn/headless')

--- a/site/content/samples/puppeteer/recorder-refactored.js
+++ b/site/content/samples/puppeteer/recorder-refactored.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-(async () => {
+const puppeteer = require('puppeteer')
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
 

--- a/site/content/samples/puppeteer/recorder-rough.js
+++ b/site/content/samples/puppeteer/recorder-rough.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-(async () => {
+const puppeteer = require('puppeteer')
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
 
@@ -19,11 +19,19 @@ const puppeteer = require('puppeteer');
   await page.waitForSelector('body > #app #button-search')
   await page.click('body > #app #button-search')
 
-  await page.waitForSelector('.shop-content > ul > .preview:nth-child(1) > .preview-details > .preview-price')
-  await page.click('.shop-content > ul > .preview:nth-child(1) > .preview-details > .preview-price')
+  await page.waitForSelector(
+    '.shop-content > ul > .preview:nth-child(1) > .preview-details > .preview-price'
+  )
+  await page.click(
+    '.shop-content > ul > .preview:nth-child(1) > .preview-details > .preview-price'
+  )
 
-  await page.waitForSelector('#app-content > .main-container > .detail > .detail-wrapper > .call-to-action')
-  await page.click('#app-content > .main-container > .detail > .detail-wrapper > .call-to-action')
+  await page.waitForSelector(
+    '#app-content > .main-container > .detail > .detail-wrapper > .call-to-action'
+  )
+  await page.click(
+    '#app-content > .main-container > .detail > .detail-wrapper > .call-to-action'
+  )
 
   await browser.close()
 })()

--- a/site/content/samples/puppeteer/request-interception-block.js
+++ b/site/content/samples/puppeteer/request-interception-block.js
@@ -1,6 +1,6 @@
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer')
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
 

--- a/site/content/samples/puppeteer/request-interception-read.js
+++ b/site/content/samples/puppeteer/request-interception-read.js
@@ -1,6 +1,6 @@
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer')
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
 

--- a/site/content/samples/puppeteer/response-interception.js
+++ b/site/content/samples/puppeteer/response-interception.js
@@ -10,9 +10,9 @@ const mockResponseObject = [
     rating: '★★★★★',
     stock: 65535
   }
-];
+]
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
 

--- a/site/content/samples/puppeteer/scraping-example-purchases.js
+++ b/site/content/samples/puppeteer/scraping-example-purchases.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-(async () => {
+const puppeteer = require('puppeteer')
+;(async () => {
   const currency = process.env.CURRENCY
   const amazonUrl = process.env.AMAZON_URL
   const amazonUser = process.env.AMAZON_USER
@@ -12,8 +12,12 @@ const puppeteer = require('puppeteer');
 
   await page.setViewport({ width: 1200, height: 1822 })
 
-  await page.waitForSelector('#nav-signin-tooltip > .nav-action-button > .nav-action-inner')
-  await page.click(' #nav-signin-tooltip > .nav-action-button > .nav-action-inner')
+  await page.waitForSelector(
+    '#nav-signin-tooltip > .nav-action-button > .nav-action-inner'
+  )
+  await page.click(
+    ' #nav-signin-tooltip > .nav-action-button > .nav-action-inner'
+  )
 
   await page.waitForSelector('#ap_email')
   await page.type('#ap_email', amazonUser)
@@ -28,8 +32,12 @@ const puppeteer = require('puppeteer');
   await page.waitForSelector('#nav-link-accountList > .nav-long-width')
   await page.click('#nav-link-accountList > .nav-long-width')
 
-  await page.waitForSelector('.ya-card__whole-card-link > .a-box > .a-box-inner > .a-row > .a-column > div')
-  await page.click('.ya-card__whole-card-link > .a-box > .a-box-inner > .a-row > .a-column > div')
+  await page.waitForSelector(
+    '.ya-card__whole-card-link > .a-box > .a-box-inner > .a-row > .a-column > div'
+  )
+  await page.click(
+    '.ya-card__whole-card-link > .a-box > .a-box-inner > .a-row > .a-column > div'
+  )
 
   await page.waitForSelector('#a-autoid-1-announce > .a-dropdown-prompt')
   await page.click('#a-autoid-1-announce > .a-dropdown-prompt')
@@ -44,8 +52,8 @@ const puppeteer = require('puppeteer');
   const pages = await page.$$('.a-normal')
 
   for (const singlePage of pages) {
-    await page.waitForSelector('.a-last')
-    prices = await page.$$eval(
+    await singlePage.waitForSelector('.a-last')
+    prices = await singlePage.$$eval(
       '.a-column:nth-child(2) .a-color-secondary.value',
       (nodes) => nodes.map((n) => n.innerText)
     )
@@ -53,15 +61,18 @@ const puppeteer = require('puppeteer');
     filteredPrices = filteredPrices.concat(
       prices.filter((price) => price.includes(currency))
     )
-    await page.waitForSelector('li.a-last')
-    await page.click('li.a-last')
+    await singlePage.waitForSelector('li.a-last')
+    await singlePage.click('li.a-last')
   }
 
   const cleanPrices = filteredPrices.map((x) => {
     return x.replace(',', '.').replace(/[^\d.,-]/g, '')
   })
 
-  const totalExpense = cleanPrices.reduce((a, b) => parseFloat(a) + parseFloat(b), 0)
+  const totalExpense = cleanPrices.reduce(
+    (a, b) => parseFloat(a) + parseFloat(b),
+    0
+  )
   console.log(`Total expense for the year: ${currency} ${totalExpense}`)
 
   await browser.close()

--- a/site/content/samples/puppeteer/search.js
+++ b/site/content/samples/puppeteer/search.js
@@ -1,50 +1,50 @@
-const puppeteer = require("puppeteer");
-const assert = require("chai").assert;
+const puppeteer = require('puppeteer')
+const assert = require('chai').assert
 
-(async () => {
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
+;(async () => {
+  const browser = await puppeteer.launch()
+  const page = await browser.newPage()
 
   const bookList = [
-    "The Foreigner",
-    "The Transformation",
-    "For Whom the Ball Tells",
-    "Baiting for Robot",
-  ];
+    'The Foreigner',
+    'The Transformation',
+    'For Whom the Ball Tells',
+    'Baiting for Robot'
+  ]
 
-  await page.goto("https://danube-webshop.herokuapp.com/");
+  await page.goto('https://danube-webshop.herokuapp.com/')
 
-  await page.setViewport({ width: 1200, height: 800 });
+  await page.setViewport({ width: 1200, height: 800 })
 
-  await page.waitForSelector(".topbar > input");
-  await page.click(".topbar > input");
+  await page.waitForSelector('.topbar > input')
+  await page.click('.topbar > input')
 
-  await page.type(".topbar > input", "for");
+  await page.type('.topbar > input', 'for')
 
-  await page.waitForSelector("#button-search");
-  await page.click("#button-search");
+  await page.waitForSelector('#button-search')
+  await page.click('#button-search')
 
   await page.waitForSelector(
-    ".shop-content > ul > .preview:nth-child(1) > .preview-title"
-  );
+    '.shop-content > ul > .preview:nth-child(1) > .preview-title'
+  )
 
   // Halt immediately if results do not equal expected number
-  let resultsNumber = (await page.$$(".preview-title")).length;
-  assert.equal(resultsNumber, bookList.length);
+  const resultsNumber = (await page.$$('.preview-title')).length
+  assert.equal(resultsNumber, bookList.length)
 
   // Remove every element found from the original array...
-  for (i = 0; i < resultsNumber; i++) {
+  for (let i = 0; i < resultsNumber; i++) {
     const resultTitle = await page.$eval(
       `.preview:nth-child(${i + 1}) > .preview-title`,
       (e) => e.innerText
-    );
+    )
 
-    const index = bookList.indexOf(resultTitle);
-    bookList.splice(index, 1);
+    const index = bookList.indexOf(resultTitle)
+    bookList.splice(index, 1)
   }
 
   // ...then assert that the original array is now empty
-  assert.equal(bookList.length, 0);
+  assert.equal(bookList.length, 0)
 
-  await browser.close();
-})();
+  await browser.close()
+})()

--- a/site/content/samples/puppeteer/signup.js
+++ b/site/content/samples/puppeteer/signup.js
@@ -1,38 +1,38 @@
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer')
 
-(async () => {
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
-  
-  await page.goto('https://danube-webshop.herokuapp.com/');
-  
-  await page.setViewport({ width: 1200, height: 800 });
-  
-  await page.waitForSelector('#signup');
-  await page.click('#signup');
-  
-  await page.waitForSelector('#s-name');
-  await page.click('#s-name');
-  
-  await page.type('#s-name', 'John');
-  await page.type('#s-surname', 'Doe');
-  await page.type('#s-email', process.env.USER_EMAIL);
-  await page.type('#s-password2', process.env.USER_PASSWORD);
-  await page.type('#s-company', 'John Doe Inc.');
-  
-  await page.waitForSelector('#business');
-  await page.click('#business');
-  
-  await page.waitForSelector('#marketing-agreement');
-  await page.click('#marketing-agreement');
-  
-  await page.waitForSelector('#privacy-policy');
-  await page.click('#privacy-policy');
-  
-  await page.waitForSelector('#register-btn');
-  await page.click('#register-btn');
-  
-  await page.waitForSelector('#login-message', { visible: true });
-  
-  await browser.close();
+;(async () => {
+  const browser = await puppeteer.launch()
+  const page = await browser.newPage()
+
+  await page.goto('https://danube-webshop.herokuapp.com/')
+
+  await page.setViewport({ width: 1200, height: 800 })
+
+  await page.waitForSelector('#signup')
+  await page.click('#signup')
+
+  await page.waitForSelector('#s-name')
+  await page.click('#s-name')
+
+  await page.type('#s-name', 'John')
+  await page.type('#s-surname', 'Doe')
+  await page.type('#s-email', process.env.USER_EMAIL)
+  await page.type('#s-password2', process.env.USER_PASSWORD)
+  await page.type('#s-company', 'John Doe Inc.')
+
+  await page.waitForSelector('#business')
+  await page.click('#business')
+
+  await page.waitForSelector('#marketing-agreement')
+  await page.click('#marketing-agreement')
+
+  await page.waitForSelector('#privacy-policy')
+  await page.click('#privacy-policy')
+
+  await page.waitForSelector('#register-btn')
+  await page.click('#register-btn')
+
+  await page.waitForSelector('#login-message', { visible: true })
+
+  await browser.close()
 })()


### PR DESCRIPTION
During my onboarding I did an extensive tour around the `/learn/headless` area. This PR includes the following:

- unify example snippet coding style to `npx prettier --no-semi`
- change wording in a few places to make it more concise
- mark Node `12` as deprecated in the runtime docs