### PR TITLE
chore: update runtime docs with deprecation warning [sc-9735]

### DIFF
--- a/site/layouts/shortcodes/runtimes.html
+++ b/site/layouts/shortcodes/runtimes.html
@@ -1,7 +1,14 @@
 {{ $Runtimes := getJSON "https://api.checklyhq.com/v1/runtimes" }}
 
 {{ range $Runtimes }}
-  <h3 id="{{.name}}">{{ .name }}</h3>
+  <h3 id="{{.name}}">{{ .name }}
+    {{ if eq .stage "DEPRECATED" }}
+    <span class="badge badge-accent">{{ .stage }}</span>
+    {{ end }}
+  </h3>
+  {{ if eq .stage "DEPRECATED" }}
+  <p class="text-accent">This runtime will be available until {{ .runtimeEndOfLife }}. Please update your checks' runtimes and account settings to avoid failures due to automatic change to the next supported runtime.</p>
+  {{ end }}
   <p>{{ .description }}</p>
   <ul>
     {{ range $key, $value := .dependencies }}


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
Updating the runtime docs to display a deprecation warning and expiration date.
Deprecated runtime:
![Screenshot 2022-06-28 at 09 38 48](https://user-images.githubusercontent.com/54396648/176123683-41c96eff-74cc-423d-a030-08298a2ff02f.png)
Stable runtime:
![Screenshot 2022-06-28 at 09 39 18](https://user-images.githubusercontent.com/54396648/176123690-b0969b06-674b-4045-927d-90b3212eacca.png)


> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
