### PR TITLE
fix: use h2 for snippets headers

### DIFF
--- a/site/content/docs/snippets/_index.md
+++ b/site/content/docs/snippets/_index.md
@@ -19,7 +19,7 @@ Snippets can be useful for:
 - a common navigation flow
 - a common setup or teardown procedure
 
-### How to use snippets
+## How to use snippets
 
 To create a snippet, access <a href="https://app.checklyhq.com/snippets" target="_blank">the snippets section on the left side of the UI</a>. 
 
@@ -37,7 +37,7 @@ Snippets can even import other snippets. Since snippets are stored in the same d
 const setupLibrary = require('./setup-library.js')
 ```
 
-### Example: GitHub login
+## Example: GitHub login
 
 Say we want to validate some parts of the GitHub website only available to logged in users. We want to have separate, small
 Browser checks to have granular feedback whether each part functions.

--- a/site/content/docs/snippets/handlebars-snippets.md
+++ b/site/content/docs/snippets/handlebars-snippets.md
@@ -11,7 +11,7 @@ menu:
 
 Snippets may also be imported using the [Handlebars](https://handlebarsjs.com/guide/partials.html) partial notation `{{> my_code_snippet }}`. When using the partials notation, code snippets are copied inline.
 
-### Example: GitHub login
+## Example: GitHub login
 
 Say we want to validate some parts of the GitHub website only available to logged in users. We want to have separate, small
 browser checks to have granular feedback whether each part functions.
@@ -73,7 +73,7 @@ in partials / snippets, just like in "normal" browser check scripts. Your snippe
 {{< /tab >}}
 {{< /tabs >}}
 
-### Passing variables to partials
+## Passing variables to partials
 
 You might want to create a partials that has a generic login routine and then pass it different username / password combinations
 based on your script. Or you might want to pass other variables to your partials.
@@ -99,7 +99,7 @@ Notice three things:
 2. The environment variables `process.env.xxx` are evaluated to a string in the partial.
 3. A standard string like the `extra="text"` pair is passed as is. Notice the extra quotes in the partial.
 
-### Using Handlebars helpers
+## Using Handlebars helpers
 
 We've extended the [Handlebars](https://handlebarsjs.com/) templating system with some handy helpers to make our webhooks
 even more powerful.


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer

The "On This Page" section of the snippets page (https://www.checklyhq.com/docs/snippets/) is blank. This is because the page is using h3 instead of h2 for the headers. This PR just updates the headers, which resolves the issue.

