### PR TITLE
feat: remove "new" label from pulumi provider

### DIFF
--- a/site/content/integrations/_index.md
+++ b/site/content/integrations/_index.md
@@ -18,7 +18,6 @@ highlights:
     image: "/integrations/highlight/pulumi-featured-image@2x.png"
     tabIcon: "/integrations/highlight/pulumi-logo.svg"
     ctaLink: "/docs/integrations/pulumi/"
-    isNew: true
   - label: VERCEL
     title: Run checks on every deploy
     description: >-


### PR DESCRIPTION
## Affected Components
* [x] Content & Marketing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [ ] Other

Had a reminder popping up to remove this `new` label here. :)

<img width="684" alt="image" src="https://user-images.githubusercontent.com/962099/183412458-daa3ce83-f130-4c25-94ec-6ea998716e62.png">
