### PR TITLE
docs: add disableTagParsing flag in prometheus docs [sc-10935]

### DIFF
--- a/site/content/docs/integrations/prometheus.md
+++ b/site/content/docs/integrations/prometheus.md
@@ -31,7 +31,7 @@ Each `checkly_check` metric has the following labels:
 - `tags`, this check's tags.
 
 {{<info>}}
-You can set `key:value` tags in your checks/groups and they will be exported as custom labels in Prometheus. For instance the tag `env:production` will be exposed as a custome label `env="production"`. You can disable this by adding the query param `useRawTags=true`.
+You can set `key:value` tags in your checks/groups and they will be exported as custom labels in Prometheus. For instance the tag `env:production` will be exposed as a custome label `env="production"`. You can disable this by adding the query param `disableTagParsing=true`.
 {{</info>}}
 
 The `checkly_private_location` metrics contain the labels:

--- a/site/content/docs/integrations/prometheus.md
+++ b/site/content/docs/integrations/prometheus.md
@@ -31,7 +31,7 @@ Each `checkly_check` metric has the following labels:
 - `tags`, this check's tags.
 
 {{<info>}}
-You can set `key:value` tags in your checks/groups and they will be exported as custom labels in Prometheus. For instance the tag `env:production` will be exposed as a custome label `env="production"`
+You can set `key:value` tags in your checks/groups and they will be exported as custom labels in Prometheus. For instance the tag `env:production` will be exposed as a custome label `env="production"`. You can disable this by adding the query param `useRawTags=true`.
 {{</info>}}
 
 The `checkly_private_location` metrics contain the labels:


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Add new `disableTagParsing` flag to the Prometheus documentation.
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
- Webapp PR https://github.com/checkly/checkly-webapp/pull/3158
- Backend PR https://github.com/checkly/checkly-backend/pull/3425
<!-- Please explain here why we need the new dependency. -->
