### PR TITLE
docs: adds docs on generic runtime variables

### DIFF
--- a/site/content/docs/api-checks/setup-teardown-scripts.md
+++ b/site/content/docs/api-checks/setup-teardown-scripts.md
@@ -156,8 +156,8 @@ Response properties are exposed a standard Javascript object. These are only ava
 
 ### General runtime variables
 
-The setup and teardown runtime also exposes a set of generic variables you can use to figure out what 
-check, check type etc. you are running. Again, these are accessible by using `process.env.CHECK_NAME` for example.
+[The setup and teardown runtime](/docs/runtimes/) also exposes a set of environment variables (e.g. process.env.CHECK_NAME)
+to figure out what check, check type etc. you are running.
 
 | property                  | description                                                | type   |
 |---------------------------|------------------------------------------------------------|--------|

--- a/site/content/docs/api-checks/setup-teardown-scripts.md
+++ b/site/content/docs/api-checks/setup-teardown-scripts.md
@@ -163,7 +163,7 @@ check, check type etc. you are running. Again, these are accessible by using `pr
 |---------------------------|------------------------------------------------------------|--------|
 | `CHECK_NAME`              | The name of the check being executed.                      | String |
 | `CHECK_ID`                | The UUID of the check being executed.                      | String |
-| `CHECK_TYPE`              | The type of the check being executed.                      | String |
+| `CHECK_TYPE`              | The type of the check being executed, (`API`)              | String |
 | `CHECK_RESULT_ID`         | The UUID of the result where the run result will be saved. | String |
 
 ## Included libraries

--- a/site/content/docs/api-checks/setup-teardown-scripts.md
+++ b/site/content/docs/api-checks/setup-teardown-scripts.md
@@ -154,6 +154,18 @@ Response properties are exposed a standard Javascript object. These are only ava
 | `response.timings`  | Various timestamps for the request stage relative to the starting time.  | Object |
 | `response.timingPhases`  | Time durations for each request phase. | Object |
 
+### General runtime variables
+
+The setup and teardown runtime also exposes a set of generic variables you can use to figure out what 
+check, check type etc. you are running. Again, these are accessible by using `process.env.CHECK_NAME` for example.
+
+| property                  | description                                                | type   |
+|---------------------------|------------------------------------------------------------|--------|
+| `CHECK_NAME`              | The name of the check being executed.                      | String |
+| `CHECK_ID`                | The UUID of the check being executed.                      | String |
+| `CHECK_TYPE`              | The type of the check being executed.                      | String |
+| `CHECK_RESULT_ID`         | The UUID of the result where the run result will be saved. | String |
+
 ## Included libraries
 
 All setup and teardown scripts run in a sandboxed environment on our cloud backend. You do not have full access to the Node.js standard library or to arbitrary NPM modules.

--- a/site/content/docs/browser-checks/variables.md
+++ b/site/content/docs/browser-checks/variables.md
@@ -91,3 +91,14 @@ You can make use of this by providing a default value for a specific variable at
 be overridden at the check level.
 
 
+## General built-in runtime variables
+
+The Browser Check runtime also exposes a set of generic variables you can use to figure out what
+check, check type etc. you are running. Again, these are accessible by using `process.env.CHECK_NAME` for example.
+
+| property                  | description                                                | type   |
+|---------------------------|------------------------------------------------------------|--------|
+| `CHECK_NAME`              | The name of the check being executed.                      | String |
+| `CHECK_ID`                | The UUID of the check being executed.                      | String |
+| `CHECK_TYPE`              | The type of the check being executed.                      | String |
+| `CHECK_RESULT_ID`         | The UUID of the result where the run result will be saved. | String |

--- a/site/content/docs/browser-checks/variables.md
+++ b/site/content/docs/browser-checks/variables.md
@@ -100,5 +100,5 @@ check, check type etc. you are running. Again, these are accessible by using `pr
 |---------------------------|------------------------------------------------------------|--------|
 | `CHECK_NAME`              | The name of the check being executed.                      | String |
 | `CHECK_ID`                | The UUID of the check being executed.                      | String |
-| `CHECK_TYPE`              | The type of the check being executed.                      | String |
+| `CHECK_TYPE`              | The type of the check being executed, (`BROWSER`)          | String |
 | `CHECK_RESULT_ID`         | The UUID of the result where the run result will be saved. | String |

--- a/site/content/docs/browser-checks/variables.md
+++ b/site/content/docs/browser-checks/variables.md
@@ -8,8 +8,8 @@ menu:
 ---
 
 When creating browser checks, you probably run some code locally, store it in a Git repo or copy and paste it around
-a bit. This means the credentials in the script are at risk of being exposed.  
-You should therefore **replace any confidential data in your browser check scripts with environment variables.**  
+a bit. This means the credentials in the script are at risk of being exposed.
+You should therefore **replace any confidential data in your browser check scripts with environment variables.**
 
 ## Managing variables
 
@@ -24,13 +24,13 @@ encrypted at rest and in flight on our back end and is only decrypted when neede
 
 ![add local variables](/docs/images/browser-checks/add-local-variable.png)
 
-Group variables are added on the **Variables** tab in a [group](/docs/groups). The variables stored here are accessible 
+Group variables are added on the **Variables** tab in a [group](/docs/groups). The variables stored here are accessible
 only in the group context.
 
 ![add group variables](/docs/images/browser-checks/add-group-variable.png)
 
-Global variables are added on the **Variables** tab. The variables stored here are globally accessible 
-throughout Checkly, hence the "Global environment variables" title. 
+Global variables are added on the **Variables** tab. The variables stored here are globally accessible
+throughout Checkly, hence the "Global environment variables" title.
 
 ![add global variables](/docs/images/browser-checks/add-global-variable.png)
 
@@ -40,7 +40,7 @@ Whenever possible, store variables at the global level. This DRY's up your code.
 
 ## Accessing variables
 
-Both check, group and global environment variables are accessible in your code using the standard Node.js `process.env.MY_VAR` notation. 
+Both check, group and global environment variables are accessible in your code using the standard Node.js `process.env.MY_VAR` notation.
 For example, the code snippet below show how you can log into GitHub. We have more [examples of login scenarios on this page.](/docs/browser-checks/login-scenarios/)
 
 {{< tabs "Variables example" >}}
@@ -73,7 +73,7 @@ await browser.close()
 ```
 
 {{< /tab >}}
-{{< /tabs >}} 
+{{< /tabs >}}
 
 > You can access the current data center location using the implicit `process.env.REGION` variable. This resolve to the AWS region name, i.e. 'us-east-1'
 
@@ -81,20 +81,20 @@ await browser.close()
 ## Variable hierarchy
 
 As browser checks are scheduled, Checkly merges the check, group and global environment variables into one data set and exposes them
-to the runtime environment. During merging, any check variable with the same name as a global or group variable **overrides that variable.**  
+to the runtime environment. During merging, any check variable with the same name as a global or group variable **overrides that variable.**
 
 Or in another words:
 
-> **check** variables trump **group** variables trump **global** variables.  
+> **check** variables trump **group** variables trump **global** variables.
 
-You can make use of this by providing a default value for a specific variable at the global or group level, but allow that variable to 
+You can make use of this by providing a default value for a specific variable at the global or group level, but allow that variable to
 be overridden at the check level.
 
 
 ## General built-in runtime variables
 
-The Browser Check runtime also exposes a set of generic variables you can use to figure out what
-check, check type etc. you are running. Again, these are accessible by using `process.env.CHECK_NAME` for example.
+[The Browser Check runtime](/docs/runtimes/) also exposes a set of environment variables (e.g. process.env.CHECK_NAME)
+to figure out what check, check type etc. you are running.
 
 | property                  | description                                                | type   |
 |---------------------------|------------------------------------------------------------|--------|


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

## Notes for the Reviewer
This was not in our docs yet but was live in the editor and backend.
