### PR TITLE
docs: add simple iframe snippets

### DIFF
--- a/site/content/learn/headless/iframes.md
+++ b/site/content/learn/headless/iframes.md
@@ -14,7 +14,7 @@ menu:
 
 Puppeteer and Playwright enable us to access and interact with iframes.
 
-## Locate the iframe and its elements
+## Locate an iframe and its elements
 
 To access iframe elements, locate the iframe and query the DOM elements as if you're in the page context.
 

--- a/site/content/learn/headless/iframes.md
+++ b/site/content/learn/headless/iframes.md
@@ -1,0 +1,36 @@
+---
+title: Interacting with iframes
+subTitle: Accessing and interacting with iframes
+date: 2022-08-25
+author: Stefan Judis
+githubUser: stefanjudis
+tags:
+  - iframes
+weight: 17
+menu:
+  learn:
+    parent: "Pages & frames"
+---
+
+Puppeteer and Playwright enable us to access and interact with iframes.
+
+## Locate the iframe and its elements
+
+To access iframe elements, locate the iframe and query the DOM elements as if you're in the page context.
+
+{{< tabs "1" >}}
+{{< tab "Playwright" >}}
+```js
+{{< readfile filename="samples/playwright/iframe-access.js" >}}
+```
+{{< /tab >}}
+{{< tab "Puppeteer" >}}
+```js
+{{< readfile filename="samples/puppeteer/iframe-access.js" >}}
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+## Further reading
+
+1. [Playwright's "Frames documentation"](https://playwright.dev/docs/frames)

--- a/site/content/samples/playwright/iframe-access.js
+++ b/site/content/samples/playwright/iframe-access.js
@@ -1,0 +1,14 @@
+const { chromium } = require('playwright')
+
+;(async () => {
+  const browser = await chromium.launch()
+  const context = await browser.newContext()
+  const page = await context.newPage()
+
+  await page.goto('https://your-page-with-an-iframe.com')
+
+  const header = await page.frameLocator('iframe').locator('h1')
+  console.log(await header.innerText())
+
+  await browser.close()
+})()

--- a/site/content/samples/puppeteer/iframe-access.js
+++ b/site/content/samples/puppeteer/iframe-access.js
@@ -1,0 +1,15 @@
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const browser = await puppeteer.launch()
+  const page = await browser.newPage()
+  await page.goto('https://your-page-with-an-iframe.com')
+
+  const iframeHandle = await page.$('iframe')
+  const iframe = await iframeHandle.contentFrame()
+  const heading = await iframe.$('h1')
+
+  console.log(await heading.evaluate((el) => el.innerText))
+
+  await browser.close()
+})()


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

Add quick iframe sections to `/learn`.

<img width="1289" alt="image" src="https://user-images.githubusercontent.com/962099/186636011-236dad9f-f6ab-459b-903b-ec3cb5482728.png">
