### PR TITLE
feat: add SOC2 information

### DIFF
--- a/site/content/security/security-response.md
+++ b/site/content/security/security-response.md
@@ -20,6 +20,10 @@ security flaw that might impact our customer and / or our products, please let u
 - We’ll investigate the issue and determine its impact. We won’t disclose issues until our investigation is finished.
 - Once the issue is resolved, we’ll post a security update along with thanks and credit for the discovery.
 
+## SOC 2 Compliance
+
+Checkly is SOC 2 compliant showing we cover security, availability, confidentiality, privacy, and processing integrity. But we aren’t stopping there. We are now in the process of completing SOC 2, Type 2 compliance. As we continue to innovate new features and capabilities for users, Checkly is committed to ensuring and protecting the privacy of our clients and their data.
+
 ## Thanks for helping small companies stay secure
 
 - [Faizan Ahmed Kahn](https://www.facebook.com/fizan.ahmed.3998)

--- a/site/data/security/faq.yml
+++ b/site/data/security/faq.yml
@@ -70,3 +70,7 @@ Additionally:
     a: The infrastructure provider tracks access to core infrastructure. Any key changes to our codebase and infrastructure follow a code review process to enforce the four-eyes principle.
   - q: Which authentication options does Checkly provide?
     a: By default, the user authenticates via user name and password. We support single sign-on via social logins (Google, Github). SAML 2.0 and integrations like Microsoft AD are available for Enterprise users.
+  - q: Is Checkly SOC 2 Compliant?
+    a: Yes, Checkly is SOC 2 compliant showing we cover security, availability, confidentiality, privacy, and processing integrity. We are now in the process of completing SOC 2, Type 2 compliance. As we continue to innovate new features and capabilities for users, Checkly is committed to ensuring and protecting the privacy of our clients and their data.
+  - q: Does Checkly authentication and infrastructure providers hold certifications?
+    a: Our authentication provider [Auth0](https://assets.ctfassets.net/kbkgmx9upatd/2KxmM5BICQ4GKgeIwA0sKu/d4f59bd579803593edcd571f1aa92ef0/Auth0_Platform_Operations.pdf) is SOC 2 Type 2, ISO 27001, and 27018 certified. Our infrastructure providers [Heroku](https://www.heroku.com/compliance) and [AWS](https://aws.amazon.com/de/compliance/programs/) maintain numerous certifications, including PCI, HIPAA, ISO, and SOC compliance.


### PR DESCRIPTION
## Affected Components
* [x] Content & Marketing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [ ] Other

Added SOC2 information on `/security`:

<img width="989" alt="image" src="https://user-images.githubusercontent.com/962099/186702718-aa9591a6-d953-41ef-8cf4-c0682555810c.png">

And `/security/security-response/`:

<img width="920" alt="image" src="https://user-images.githubusercontent.com/962099/186703017-8e849217-79c4-4966-8dc2-8ec954e81094.png">
