### PR TITLE
docs: explain how to trust TLS certs in agent

### DIFF
--- a/site/content/docs/private-locations/checkly-agent-guide.md
+++ b/site/content/docs/private-locations/checkly-agent-guide.md
@@ -167,6 +167,16 @@ If you lose track of which agent containers are using the old API key, you can u
 
 9) Click Save to close the dialog. You will now only see the new API key listed for the private location.
 
+## Trusing Enterprise TLS Certificates
+
+Some enterprise environments may use internal certificates for TLS connections. These certificates need to be trusted by the agent; otherwise, the agent's TLS connection to the Checkly platform will fail. 
+
+To configure the agent to trust the certificate, first copy the certificate as a PEM file onto the host. The Docker run command should then be updated to mount the certificate as a volume and pass the path to the certificate in the `NODE_EXTRA_CA_CERTS` environment variable. For a certificate stored at the path `~/certificate.pem`, the Docker run command will be:
+
+```
+docker run -v ~/certificate.pem:/checkly/certificate.pem -e NODE_EXTRA_CA_CERTS=/checkly/certificate.pem -e API_KEY="pl_...." -d ghcr.io/checkly/agent:latest
+```
+
 ## Checkly Agent environment variables
 
 Checkly agent has several environment variables that can be configured:


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [x] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
It's come up that users need the Checkly agent to trust internal TLS certificates. This PR adds documentation explaining the necessary steps for this.

Another approach is to just set `NODE_TLS_REJECT_UNAUTHORIZED=0` - disabling all TLS certificate validation. This is insecure, but it's simpler since you don't need the certificate to get things working. We could consider mentioning this approach for debugging purposes, but I'm not sure if it's worth it.