### PR TITLE
refactor: load intercom script on page load [sc-12058]

### DIFF
--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -62,9 +62,9 @@
             custom_launcher_selector: '.open-intercom-link'
           })
 
-        	window.removeEventListener('scroll', intercomLoader)
+        	window.removeEventListener('DOMContentLoaded', intercomLoader)
       }
-  	window.addEventListener('scroll', intercomLoader)
+  	window.addEventListener('DOMContentLoaded', intercomLoader)
   </script>
 
   <!-- Google Tag Manager -->


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
The intercom script was only loaded on scroll. This results in a significant delay of having the intercom banner visible.
Changing the eventListener to `DOMContentLoaded` reduces our lighthouse score slightly but not too much.

https://user-images.githubusercontent.com/54396648/196427676-796aa2d9-a3d0-4317-8635-2f7c6b4b97cf.mp4


### Lighthouse Scores Desktop
- using `scroll`
<img width="601" alt="desktop-scroll" src="https://user-images.githubusercontent.com/54396648/196425181-b417440c-97b6-4f00-ac5a-8689516116c9.png">

- using `DOMContentLoaded`
<img width="594" alt="desktop-dcl" src="https://user-images.githubusercontent.com/54396648/196425201-76603807-2841-45d2-8a2f-23daa8c1c575.png">

### Lighthouse Scores Mobile
- using `scroll`
<img width="597" alt="mobile-scroll" src="https://user-images.githubusercontent.com/54396648/196425244-bf14c790-1bf1-4453-91df-e4e37e8d7bbc.png">

- using `DOMContentLoaded`
<img width="599" alt="mobile-dcl" src="https://user-images.githubusercontent.com/54396648/196425263-456a16d9-c435-40b6-8e4f-d5f3614a1399.png">


> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
