### PR TITLE
docs: add to the documentation that we only support US instance [sc-0]

### DIFF
--- a/site/content/docs/integrations/pagerduty.md
+++ b/site/content/docs/integrations/pagerduty.md
@@ -14,6 +14,12 @@ to your Pagerduty account. After setting up the integration, Checkly will:
 1. Trigger alerts in Pagerduty when a check fails.
 2. Resolve alerts when a check recovers.
 
+{{<info >}}
+
+Checkly currently on supports the US instance of Pagerduty
+
+{{</info >}}
+
 Setup is as simple as following the three-step Pagerduty connect process. You can add as many Pagerduty channels as
 you wish.
 

--- a/site/content/docs/integrations/pagerduty.md
+++ b/site/content/docs/integrations/pagerduty.md
@@ -16,7 +16,7 @@ to your Pagerduty account. After setting up the integration, Checkly will:
 
 {{<info >}}
 
-Checkly currently on supports the US instance of Pagerduty
+Checkly currently only supports the US instance of Pagerduty
 
 {{</info >}}
 


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [x] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Add it to the docs that we only support the US instance of pagerduty at the moment