### PR TITLE
docs: document read-only locked env var behaviour [sc-10987]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2485,7 +2485,7 @@
     "caniuse-api": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-2.0.0.tgz",
-      "integrity": "sha512-425yJRcUDCCMKc0Zga2KSUe7Qp7nCtL8H0BJIsDxF9yMzG2eSYvOggi5U1wXzxgcSgDGnzVLvZ8dZGMBrA6Ltg==",
+      "integrity": "sha1-sd21pZZrFvSNxJmERNS7xsfZ2DQ=",
       "requires": {
         "browserslist": "^2.0.0",
         "caniuse-lite": "^1.0.0",
@@ -14180,7 +14180,7 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2485,7 +2485,7 @@
     "caniuse-api": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-2.0.0.tgz",
-      "integrity": "sha1-sd21pZZrFvSNxJmERNS7xsfZ2DQ=",
+      "integrity": "sha512-425yJRcUDCCMKc0Zga2KSUe7Qp7nCtL8H0BJIsDxF9yMzG2eSYvOggi5U1wXzxgcSgDGnzVLvZ8dZGMBrA6Ltg==",
       "requires": {
         "browserslist": "^2.0.0",
         "caniuse-lite": "^1.0.0",
@@ -14180,7 +14180,7 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
           "dev": true
         }
       }

--- a/site/content/docs/browser-checks/variables.md
+++ b/site/content/docs/browser-checks/variables.md
@@ -19,8 +19,7 @@ For browser checks, you can create environment variables at three hierarchical l
 - **Group** level
 - **Global** level
 
-Check variables are added on the **Variables** tab for each browser check. Any data you "lock" is
-encrypted at rest and in flight on our back end and is only decrypted when needed.
+Check variables are added on the **Variables** tab for each browser check. 
 
 ![add local variables](/docs/images/browser-checks/add-local-variable.png)
 
@@ -37,6 +36,12 @@ throughout Checkly, hence the "Global environment variables" title.
 {{<info >}}
 Whenever possible, store variables at the global level. This DRY's up your code.
 {{</info>}}
+
+Any data you "lock" is encrypted at rest and in flight on our back end and is only decrypted when needed. 
+Locked environment variables can only be accessed by team members with [Read & Write access](/docs/accounts-and-users/) or above.
+
+Keep in mind, though, that Read Only team members will still have access to information on the [check results page](/docs/monitoring/check-results/#browser-check-results).
+If you want to avoid team members with Read Only access from viewing environment variables, avoid logging secrets during your check.
 
 ## Accessing variables
 


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
We recently removed access to locked environment variables for read-only users. We can add this to the docs now.

[The updated page is here.](https://checklyhq-6ghpzn1x2-checkly.vercel.app//docs/browser-checks/variables/)
