### PR TITLE
docs: add triple brackets callout on webhooks page

### DIFF
--- a/site/content/docs/alerting/webhooks.md
+++ b/site/content/docs/alerting/webhooks.md
@@ -24,6 +24,10 @@ The example above shows a webhook configured to create a Jira ticket on each eve
 
 In both cases we use the familiar Handlebars templating braces, i.e. `{{ }}` to insert the variable.
 
+{{<info >}}
+To avoid encoding, you can access your environment variables with triple brackets, i.e. `{{{USER_API_KEY}}}`
+{{</info >}}
+
 You can use the following event-related variables in both URL and payload.
 
 | Variable            | Description                                                  |


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Notes for the Reviewer
Related to https://app.intercom.com/a/apps/ep3ft8gg/inbox/inbox/4015446