### PR TITLE
fix: dynamically append utm tags to all links to the webapps /signup page [sc-12942]

### DIFF
--- a/site/layouts/partials/navbar.html
+++ b/site/layouts/partials/navbar.html
@@ -239,11 +239,9 @@ if (window.location.search) {
   const utmContent = params.get('utm_content')
   if (utmContent) newParams.set('utm_content', utmContent)
 
-  const loginButton = document.querySelector('#login-button')
-  loginButton.href = `https:\/\/app.checklyhq.com/?${newParams.toString()}`
-  const dashboardButton = document.querySelector('#dashboard-button')
-  dashboardButton.href = `https:\/\/app.checklyhq.com/?${newParams.toString()}`
-  const signupButton = document.querySelector('#nav-signup-button')
-  signupButton.href = `https:\/\/app.checklyhq.com/signup?${newParams.toString()}`
+  const signupLinks = document.querySelectorAll('a[href*="app.checklyhq.com/signup"]')
+  signupLinks.forEach(link => {
+    link.href += `?${newParams.toString()}`
+  })
 }
 </script>

--- a/site/layouts/partials/navbar.html
+++ b/site/layouts/partials/navbar.html
@@ -239,7 +239,7 @@ if (window.location.search) {
   const utmContent = params.get('utm_content')
   if (utmContent) newParams.set('utm_content', utmContent)
 
-  const signupLinks = document.querySelectorAll('a[href*="app.checklyhq.com/signup"]')
+  const signupLinks = document.querySelectorAll('a[href*="app.checklyhq.com"]')
   signupLinks.forEach(link => {
     link.href += `?${newParams.toString()}`
   })


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

- Instead of hardcoded appending of UTM tags to 3 links to our webapps `/signup` page in the nav and hero section, we will change it to dynamically fetch all nodes with `a[href*="app.checklyhq.com"]'` and append them to all of the results.

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->

## Screenshots
<!-- Screenshot of any visual changes -->
