### PR TITLE
fix: focus styling on pricing cards cta btns [sc-00]

### DIFF
--- a/src/scss/_pricing-v2.scss
+++ b/src/scss/_pricing-v2.scss
@@ -256,6 +256,10 @@
       transform: translateX(-50%);
       bottom: -20px;
       font-size: 0.9rem;
+
+      &:focus {
+        color: white !important;
+      }
     }
   }
 


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

- Fix `:focus` styling on these pricing card cta btns. See screenshots below.

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->

## Screenshots
<!-- Screenshot of any visual changes -->

Before:
![image](https://user-images.githubusercontent.com/7415984/206228677-69924ec9-3080-440b-91c4-6de4fdfdfd58.png)


After:

![image](https://user-images.githubusercontent.com/7415984/206228615-6cc4cff5-cb10-478a-9e8a-c07e8aafa54b.png)