### PR TITLE
fix: always set utm_originalsource and utm_originalmedium

### DIFF
--- a/site/layouts/partials/scripts.html
+++ b/site/layouts/partials/scripts.html
@@ -53,6 +53,7 @@ if (window.location.search || utmTags) {
   window.localStorage.setItem('checkly.utm_tags_entry', new Date().toISOString())
   if (localStorage.getItem('checkly.utm_tags_original_source') === null) {
     window.localStorage.setItem('checkly.utm_tags_original_source', params.get('utm_source'))
+    newParams.set('utm_originalsource', params.get('utm_source'))
   }
 
   // Append new params to all app.checklyhq.com links and add onClick handler to clear

--- a/site/layouts/partials/scripts.html
+++ b/site/layouts/partials/scripts.html
@@ -29,10 +29,12 @@ const utmParams = [
 const utmTags = localStorage.getItem('checkly.utm_tags');
 const utmTagEntry = localStorage.getItem('checkly.utm_tags_entry');
 const utmOriginalSource = localStorage.getItem('checkly.utm_tags_original_source');
+const utmOriginalMedium = localStorage.getItem('checkly.utm_tags_original_medium');
 
 if (window.location.search || utmTags) {
   const newParams = new URLSearchParams()
   if (utmOriginalSource) newParams.set('utm_originalsource', utmOriginalSource)
+  if (utmOriginalMedium) newParams.set('utm_originalmedium', utmOriginalMedium)
 
   // Set params from location.search or the saved utm tags
   let params
@@ -51,9 +53,17 @@ if (window.location.search || utmTags) {
   // Persist new params to localstorage
   window.localStorage.setItem('checkly.utm_tags', newParams.toString())
   window.localStorage.setItem('checkly.utm_tags_entry', new Date().toISOString())
+
+  // Save `utm_originalsource` to localStorage
   if (localStorage.getItem('checkly.utm_tags_original_source') === null) {
     window.localStorage.setItem('checkly.utm_tags_original_source', params.get('utm_source'))
     newParams.set('utm_originalsource', params.get('utm_source'))
+  }
+
+  // Save `utm_originalmedium` to localStorage
+  if (localStorage.getItem('checkly.utm_tags_original_medium') === null) {
+    window.localStorage.setItem('checkly.utm_tags_original_medium', params.get('utm_medium'))
+    newParams.set('utm_originalmedium', params.get('utm_medium'))
   }
 
   // Append new params to all app.checklyhq.com links and add onClick handler to clear
@@ -64,6 +74,7 @@ if (window.location.search || utmTags) {
       window.localStorage.removeItem('checkly.utm_tags')
       window.localStorage.removeItem('checkly.utm_tags_entry')
       window.localStorage.removeItem('checkly.utm_tags_original_source')
+      window.localStorage.removeItem('checkly.utm_tags_original_medium')
     });
   })
 }


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

- Sets the `utm_originalsource` even on the first visit
- Sets `utm_originalmedium` as well for more detailed attribution

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->

## Screenshots
<!-- Screenshot of any visual changes -->
