### PR TITLE
Add Incidents and Custom dashboard CSS to pricing

### DIFF
--- a/site/layouts/pricing/list.html
+++ b/site/layouts/pricing/list.html
@@ -116,7 +116,7 @@
             <div class="font-weight-bold">Starting at</div>
             <div class="pricing__fancy-price justify-content-center">
               <div class="pricing__fancy-price__dollar-sign pricing__fancy-price__dollar-sign--big pricing__fancy-price__dollar-sign--white">$</div>
-              <div class="pricing__fancy-price__price pricing__fancy-price__price--big pricing__fancy-price__price--white">1500</div>
+              <div class="pricing__fancy-price__price pricing__fancy-price__price--big pricing__fancy-price__price--white">1,500</div>
             </div>
             <div>per month</div>
           </div>
@@ -337,7 +337,7 @@
           </tr>
           <tr>
             <th>Browser check runs</th>
-            <td>5000 / month</td>
+            <td>5,000 / month</td>
             <td>Additional at $5/1K</td>
             <td>Custom</td>
           </tr>

--- a/site/layouts/pricing/list.html
+++ b/site/layouts/pricing/list.html
@@ -488,6 +488,18 @@
             <td><i class="ion-ios-checkmark text-success"></i></td>
           </tr>
           <tr>
+            <th>Incident management</th>
+            <td><i class="ion-close-circled text-muted"></i></td>
+            <td><i class="ion-ios-checkmark text-success"></i></td>
+            <td><i class="ion-ios-checkmark text-success"></i></td>
+          </tr>
+          <tr>
+            <th>Public dashboards custom CSS</th>
+            <td><i class="ion-close-circled text-muted"></i></td>
+            <td><i class="ion-ios-checkmark text-success"></i></td>
+            <td><i class="ion-ios-checkmark text-success"></i></td>
+          </tr>
+          <tr>
             <th>SMS credits</th>
             <td><i class="ion-close-circled text-muted"></i></td>
             <td>200*</td>


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [x] Pricing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

I also updated two typos where currency wasn't formatted properly. The enterprise price of $1,500 was formatted as $1500 and browser check runs were shown as 5000 without the thousand separator.