### PR TITLE
feat: add link to MaC on homepage [sc-14224]

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -15,7 +15,7 @@ disqusShortname = "checkly"
   blog = "/blog/:year/:month/:title/"
 
 [params]
-    description = "Monitoring as Code workflow for developers: programmable, fast, reliable."
+    description = "Monitoring as code workflow for developers: programmable, fast, reliable."
 
 [[menu.docs]]
 	name = "Monitoring"

--- a/site/layouts/partials/hero-section.html
+++ b/site/layouts/partials/hero-section.html
@@ -3,7 +3,7 @@
     <div class="row justify-content-center">
       <div class="col-sm-12 col-md-10 col-lg-8">
         <h1 class="display-3">Build and Run Synthetics<br/>That Scale</h1>
-        <p class="lead">Monitoring as Code workflow for developers: programmable, fast, reliable.</p>
+        <p class="lead"><a href="https://www.checklyhq.com/product/monitoring-as-code/">Monitoring as code</a> workflow for developers: programmable, fast, reliable.</p>
         <div>
           <a id="signup-button" class="signup-button btn btn-success btn-lg" data-signup="data-signup" href="https://app.checklyhq.com/signup" rel="noopener">
             Start for free


### PR DESCRIPTION
## Affected Components
* [X] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
Add link to MaC site on the homepage
