### PR TITLE
docs: mentions prereq in extended installation docs

### DIFF
--- a/site/content/docs/cli/installation.md
+++ b/site/content/docs/cli/installation.md
@@ -7,7 +7,14 @@ menu:
 ---
 
 To kickstart a new project with the CLI, we recommend running `npm create @checkly/cli`. But you can also add the CLI
-from scratch with the following steps. 
+from scratch with the following steps.
+
+## Prerequisites
+
+- Node.js `v16.x` or higher.
+- A text editor like [Visual Studio Code](https://code.visualstudio.com/).
+
+## Installation
 
 First, install the CLI.
 


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

## Notes for the Reviewer
mini update to show Node.js 16 prereq
