### PR TITLE
fix: remove pricing from enterprise plan [sc-14648]

### DIFF
--- a/site/layouts/pricing/list.html
+++ b/site/layouts/pricing/list.html
@@ -103,12 +103,9 @@
           <div class="pricing__card pricing__card--small pricing__card--black">
             <h3 class="">Enterprise</h3>
             <div class="pricing__card--pricing-details">
-              <div class="font-weight-bold">Starting at</div>
               <div class="pricing__fancy-price justify-content-center">
-                <div class="pricing__fancy-price__dollar-sign pricing__fancy-price__dollar-sign--big pricing__fancy-price__dollar-sign--white">$</div>
-                <div class="pricing__fancy-price__price pricing__fancy-price__price--big pricing__fancy-price__price--white">1,500</div>
+                <div class="pricing__fancy-price__price pricing__fancy-price__price--big pricing__fancy-price__price--white">Custom</div>
               </div>
-              <div>per month</div>
             </div>
             <div class="pricing__btn__wrapper">
               <button type="button" class="btn btn-secondary pricing__btn__secondary pricing__btn mb-3" data-toggle="modal" data-target="#contact-sales-modal">


### PR DESCRIPTION
## Affected Components
* [X] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
Replace price from enterprise plan for "Custom"

## Screenshots
<!-- Screenshot of any visual changes -->
