### PR TITLE
chore: only update checks on production deployments

### DIFF
--- a/.github/workflows/checkly.yml
+++ b/.github/workflows/checkly.yml
@@ -28,5 +28,5 @@ jobs:
           -e ENVIRONMENT_URL=${{ env.ENVIRONMENT_URL }}
         continue-on-error: false
       - name: Deploy checks
-        if: steps.run-checks.outcome == 'success' && github.event.deployment_status.environment == 'Preview'
+        if: steps.run-checks.outcome == 'success' && github.event.deployment_status.environment == 'Production'
         run: npm run checkly:deploy

--- a/.github/workflows/checkly.yml
+++ b/.github/workflows/checkly.yml
@@ -28,5 +28,5 @@ jobs:
           -e ENVIRONMENT_URL=${{ env.ENVIRONMENT_URL }}
         continue-on-error: false
       - name: Deploy checks
-        if: steps.run-checks.outcome == 'success'
+        if: steps.run-checks.outcome == 'success' && github.event.deployment_status.environment == 'Preview'
         run: npm run checkly:deploy


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [x] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
We currently deploy checks for MaC with each PR ([f.ex, here](https://github.com/checkly/checklyhq.com/actions/runs/4477517155/jobs/7869139769)). Since PR's aren't yet reviewed and approved, though, we shouldn't be deploying the checks.

With this PR, the checks will only be deployed when there's a production Vercel. This will make sure that the deployed checks are always using `main` rather than code from PR branches.