### PR TITLE
fix: add scroll-margin-top to docs [sc-00]

### DIFF
--- a/src/scss/_docs.scss
+++ b/src/scss/_docs.scss
@@ -394,6 +394,10 @@
 
     .heading-anchor {
       color: $black;
+
+      & > * {
+        scroll-margin-top: 3rem;
+      }
     }
 
     .breadcrumb {


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

- Add `scroll-margin-top` to `/docs` pages so when one clicks on a header to scroll to, it isn't hidden under the top banner, for example.

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->

## Screenshots
<!-- Screenshot of any visual changes -->

For example, when I click on "Local Docker Workflow":

Before:
![image](https://user-images.githubusercontent.com/7415984/231501837-66ad875e-3f5f-4d0e-b3db-58b3fddfbc83.png)


After:
![image](https://user-images.githubusercontent.com/7415984/231501693-5e222de5-2b99-4864-89c0-a4629b3b766a.png)

