### PR TITLE
chore: add a homepage check

### DIFF
--- a/__checks__/homepage.spec.ts
+++ b/__checks__/homepage.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test'
+import { ChecklySitePage } from './poms/ChecklySitePage'
+
+test('homepage', async ({ page }) => {
+  await page.route('https://alb.reddit.com/*', async route => {
+    console.log('https://alb.reddit.com')
+    await route.abort()
+  })
+  const checklyPage = new ChecklySitePage(page)
+  const response = await checklyPage.goto('/')
+
+  await checklyPage.screenshot('homepage')
+
+  expect(response?.status()).toBeLessThan(399)
+})

--- a/__checks__/poms/ChecklySitePage.ts
+++ b/__checks__/poms/ChecklySitePage.ts
@@ -10,7 +10,8 @@ export class ChecklySitePage {
 
   async goto (uri = '/') {
     await this.page.setViewportSize(defaults.playwright.viewportSize)
-    await this.page.goto(defaults.baseURL + uri)
+    const response = await this.page.goto(defaults.baseURL + uri)
+    return response
   }
 
   async screenshot (name) {


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [x] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Our production monitoring account still has the check "Mission critical checks > www.checklyhq.com` which is not managed by MaC. For stability, we would like to migrate all checks to MaC, though.

This PR adds the check here. Even though this repository doesn't currently host the homepage, it seemed like the best fit. This means that the check will no longer be in the "Mission critical checks" group, though.