### PR TITLE
feat: remove 'public' mentions for dashboards feature [sc-15375]

### DIFF
--- a/site/content/docs/dashboards/_index.md
+++ b/site/content/docs/dashboards/_index.md
@@ -12,12 +12,12 @@ aliases:
   - "/docs/dashboards/"
 ---
 
-Checkly Public Dashboards are dashboards you can use to communicate check status and incidents to non-Checkly users. Use
-them as a status page for your app, service or as a dashboard on a wall mounted TV in the office.
+You can use Checkly Dashboards to communicate check status and incidents to non-Checkly users. Use
+them as a status page for your app, a service or as a dashboard on a wall-mounted TV in the office.
 
 ![Dashboard example](/docs/images/dashboards-v2/public-dashboard-1.png)
 
-Public Dashboards allow you to do the following:
+Dashboards allow you to do the following:
 
 - Show the status of all your checks, or a subset by filtering by `tag`.
 - Show the availability and p95 / p99 response times over the last 24 hours, 7 days and 30 days.

--- a/site/content/docs/dashboards/dashboard-customization.md
+++ b/site/content/docs/dashboards/dashboard-customization.md
@@ -8,20 +8,20 @@ menu:
 
 ## Checkly URL
 
-Every public dashboard comes with a configurable custom subdomain under the `checkly-dashboards.com` domain. By default,
+Every dashboard comes with a configurable custom subdomain under the `checkly-dashboards.com` domain. By default,
 we generate a random ID. You can change this subdomain to anything you like as long as it is unique among all Checkly users.
 Typically, a company name works best, e.g. `acme.checkly-dashboards.com`
 
-![custom url for public dashboard](/docs/images/dashboards-v2/custom_url.png)
+![custom url for your dashboard](/docs/images/dashboards-v2/custom_url.png)
 
 
 ## Custom Domain
 
-You can host your public dashboard under your own domain. To make this work, you need to do two things:
+You can host your dashboard under your own domain. To make this work, you need to do two things:
 
 1. Add a valid custom domain to your dashboard setting.
 
-![custom domain for public dashboard](/docs/images/dashboards-v2/custom_domain.png)
+![custom domain for your dashboard](/docs/images/dashboards-v2/custom_domain.png)
 
 2. Create a CNAME record in your DNS that points to **checkly-dashboards.com**
 
@@ -37,11 +37,11 @@ your DNS. You will see a notice similar to the one below.
 
 ## Incidents
 
-You can toggle on/off whether incidents are shown on your public dashboard.
+You can toggle on/off whether incidents are shown on your dashboard.
 
 ## Look & Feel
 
-You can tweak the following parts of your public dashboard:
+You can tweak the following parts of your dashboard:
 
 ![config public monitoring dashboard 1](/docs/images/dashboards/look_feel1.png)
 

--- a/site/content/docs/dashboards/dashboard-url.md
+++ b/site/content/docs/dashboards/dashboard-url.md
@@ -9,20 +9,20 @@ menu:
 
 ## Custom URL
 
-Every public dashboard comes with a configurable custom subdomain under the checklyhq.com domain. By default, we generate
+Every dashboard comes with a configurable custom subdomain under the checklyhq.com domain. By default, we generate
 a random ID. You can change this subdomain to anything you like as long as it is unique among all Checkly users.
 Typically a company name works best.
 
-![custom url for public dashboard](/docs/images/dashboards/custom_url.png)
+![custom url for your dashboard](/docs/images/dashboards/custom_url.png)
 
 
 ## Custom Domain
 
-You can host your public dashboard under your own domain. To make this work, you need to do two things:
+You can host your dashboard under your own domain. To make this work, you need to do two things:
 
 1. Add a valid custom domain to your dashboard setting.
 
-![custom domain for public dashboard](/docs/images/dashboards/custom_domain.png)
+![custom domain for your dashboard](/docs/images/dashboards/custom_domain.png)
 
 2. Create a CNAME record in your DNS that points to **dashboards.checklyhq.com**
 

--- a/site/content/docs/dashboards/incidents.md
+++ b/site/content/docs/dashboards/incidents.md
@@ -7,7 +7,7 @@ menu:
 ---
 
 Using **Incidents** you can communicate outages and planned maintenance to your audience — customers, co-workers, partners —
-or whoever might be lucky enough to visit one of your public dashboards. This turns your public dashboard into a status page!
+or whoever might be lucky enough to visit one of your dashboards. This turns your dashboard into a status page!
 
 Note that incidents are nested under dashboards. This means you can have multiple dashboards for different audiences (with
 different custom domains). Use cases are:
@@ -22,7 +22,7 @@ Incidents are available on any paid Checkly plan.
 
 ## Creating incidents
 
-You can quickly create an incident directly from the [dashboards overview page](https://app.checklyhq.com/dashes) and 
+You can quickly create an incident directly from the [dashboard's overview page](https://app.checklyhq.com/dashes) and 
 publish it to your dashboard in seconds. Things might be on fire. You want to be quick!
 
 ![create an incident](/docs/images/dashboards-v2/create_incident.png)
@@ -42,8 +42,8 @@ Here is an example:
 
 ## Incident updates
 
-For the **major impact** and **minor impact** incidents, you can add updates as you resolve the matter at hand. At each 
-stage you can add an updated message, which will show up on your public dashboard to keep your
+For the **major impact** and **minor impact** incidents, you can add updates as you resolve the matter at hand. At each
+stage you can add an updated message, which will show up on your dashboard to keep your
 audience in the loop. 
 
 It's very simple:
@@ -52,13 +52,13 @@ It's very simple:
 2. Add some clarifying text in the **Update Message** text field.
 
 You can edit any updates later to correct typos. You can also add more updates within the same category of updates, for
-instance if the "Investigating" phase is taking longer than expected and you want to post an update.
+instance, if the "Investigating" phase is taking longer than expected and you want to post an update.
 
 Here's an example of what that would look like while typing out the update messages.
 
 ![updating an incident](/docs/images/dashboards-v2/incident_updates.png)
 
-All incidents and their updates will show up on your public dashboard (if you have Incidents enabled for the relevant dashboard)
+All incidents and their updates will show up on your dashboard (if you have Incidents enabled for the relevant dashboard)
 in a chronological list for later reference.
 
 ![dashboard incident list](/docs/images/dashboards-v2/dashboard_incident_list.png)

--- a/site/content/docs/terraform-provider/dashboards.md
+++ b/site/content/docs/terraform-provider/dashboards.md
@@ -1,19 +1,19 @@
 ---
-title: Public dashboards
+title: Dashboards
 weight: 5
 menu:
   integrations:
     parent: "Terraform provider"
 ---
 
-[Public dashboards](/docs/dashboards/) allow you to display checks and their related metrics on a single page. They come with their own dedicated resource:
+[Dashboards](/docs/dashboards/) allow you to display checks and their related metrics on a single page. They come with their own dedicated resource:
 
 ```terraform
 resource "checkly_dashboard" "dashboard-main" {
   custom_url      = "danube"   // A unique subdomain name under "checklyhq.com"
   custom_domain   = "status.danube.com" // A custom user domain
   logo            = "https://www.danube-web.shop/logo.png"  // URL pointing to an image/logo for the page
-  header          = "Public dashboard"  // What text to display at the top of your dashboard
+  header          = "My dashboard"  // What text to display at the top of your dashboard
   refresh_rate    = 60          // How often to refresh the dashboard in seconds
   paginate        = false       // Determines if pagination is on or off
   pagination_rate = 30          // How often to trigger pagination in seconds

--- a/site/content/product/dashboards.mmark
+++ b/site/content/product/dashboards.mmark
@@ -19,9 +19,9 @@ Our dashboards give you ultimate control over how and where you share essential 
 
 <section class="grid-section">
 <div class="row">
-{{< sm-4-col-item "COMMUNICATE AND SHARE" "Use our public dashboards to communicate the real-time status of a service to your users, both inside and outside of your organization." >}}
+{{< sm-4-col-item "COMMUNICATE AND SHARE" "Use our dashboards to communicate the real-time status of a service to your users, both inside and outside of your organization." >}}
 {{< sm-4-col-item "OPTIMIZE FOR ACCESSIBILITY" "Give your dashboards clarity, readability, and responsiveness to make monitoring data easy to consume." >}}
-{{< sm-4-col-item "CREATE YOUR OWN DOMAIN" "Configure custom subdomains for added personalization in public dashboards, like status.acme.com." >}}
+{{< sm-4-col-item "CREATE YOUR OWN DOMAIN" "Configure custom subdomains for added personalization in dashboards, like status.acme.com." >}}
 {{< sm-4-col-item "BRAND AND CUSTOMIZE" "Personalize the look and feel of your dashboard using custom CSS rules—including a built-in CSS editor—to align to your company’s brand." >}}
 {{< sm-4-col-item "MONITOR WITH CONFIDENCE" "Our new dashboards are built on NuxtJS 3 and leverage NuxtJS Universal Rendering capabilities for speed and reliability." >}}
 {{< sm-4-col-item "MANAGE INCIDENTS" "Use the incident management feature to communicate scheduled maintenance notices and notify customers about incidents directly from the dashboard overview page." >}}
@@ -50,7 +50,7 @@ Our dashboards give you ultimate control over how and where you share essential 
     <div class="col-sm-12 col-md-8">
       <h2 class="section-header mt-1">Checkly URL and Custom Domains</h2>
       <p class="lead-text mb-lg-2">
-      You can host your public dashboard under your own custom domain. You’ll just need to add a valid custom domain to your dashboard setting, and then create a CNAME record in your DNS that points to checkly-dashboards.com.
+      You can host your dashboard under your own custom domain. You’ll just need to add a valid custom domain to your dashboard setting, and then create a CNAME record in your DNS that points to checkly-dashboards.com.
       </p>
     </div>
     <div class="lead-text mt-5 text-center">

--- a/site/data/pricing/faq.yml
+++ b/site/data/pricing/faq.yml
@@ -14,7 +14,7 @@ questions:
   - q: What does fair use mean?
     a: Fair use limits are soft boundaries that apply to certain features. The limits are set in a way that most customers
       should not encounter any limitations. On a Team plan, you can invite up to 99 users, have
-      25 public dashboards, and 200 SMS alerts per month. If you exceed the thresholds, we will reach out and discuss options with you.
+      25 dashboards, and 200 SMS alerts per month. If you exceed the thresholds, we will reach out and discuss options with you.
   - q: Can I upgrade or downgrade my plan?
     a: "For the **Hobby plan** upgrades and downgrades don't apply.<br><br>
       **Downgrade Team plan**: You can reduce the number of prepaid checks from account settings. The changes will apply after

--- a/site/layouts/partials/all-features.html
+++ b/site/layouts/partials/all-features.html
@@ -29,8 +29,8 @@
       </div>
       <div class="col-sm-6 col-md-6 col-lg-4">
         <div class="block">
-          <h5>Public dashboards</h5>
-          <p>Display a <a class="info-link" href='/docs/dashboards/'>public dashboard</a> on your site or in-office
+          <h5>Dashboards</h5>
+          <p>Display a <a class="info-link" href='/docs/dashboards/'>dashboard</a> on your site or in-office
             mounted TV, hosted on your company domain.</p>
         </div>
       </div>

--- a/site/layouts/pricing/list.html
+++ b/site/layouts/pricing/list.html
@@ -347,7 +347,7 @@
             <td>Custom</td>
           </tr>
           <tr>
-            <th>Public dashboards</th>
+            <th>Dashboards</th>
             <td>1</td>
             <td>10</td>
             <td>Unlimited*</td>
@@ -471,7 +471,7 @@
             <td><i class="ion-ios-checkmark text-success"></i></td>
           </tr>
           <tr>
-            <th>Public dashboards custom CSS</th>
+            <th>Dashboards custom CSS</th>
             <td><i class="ion-close-circled text-muted"></i></td>
             <td><i class="ion-ios-checkmark text-success"></i></td>
             <td><i class="ion-ios-checkmark text-success"></i></td>


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

Since dashboards will get the `private` option soon, I'm removing mentions of "public" in the docs and marketing site.
