### PR TITLE
refacor: remove `/public-stats` endpoint usage [sc-15393]

### DIFF
--- a/site/content/docs/api-checks/setup-teardown-scripts.md
+++ b/site/content/docs/api-checks/setup-teardown-scripts.md
@@ -101,7 +101,7 @@ import axios from 'axios'
 
 export async function getToken () {
     console.log('Fetching session token from auth server')
-    const { data } = await axios.get('https://api.checklyhq.com/public-stats', {
+    const { data } = await axios.get('https://api.checklyhq.com/v1/runtimes', {
         headers: {
             authentication: process.env.AUTH_SERVER_TOKEN
         }

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -19,7 +19,6 @@
       {{ partial "read-case-stuides" . }}
       {{ partial "testimonial-three-col-row" . }}
       {{ partial "all-features" . }}
-      {{ partial "public-stats-section" . }}
     </div>
   </div>
   {{ partial "footer" . }}

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -27,25 +27,6 @@ $(document).ready(() => {
 })
 
 /**
- * END Navbar
- */
-
-$(document).ready(() => {
-  if ($('body').hasClass('landing')) {
-    fetch('https://api.checklyhq.com/public-stats')
-      .then(function (response) {
-        return response.json()
-      })
-      .then(function (res) {
-        const countApi = res.apiCheckResults.toLocaleString()
-        const countBrowser = res.browserCheckResults.toLocaleString()
-        $('#api-check-results').text(countApi)
-        $('#browser-check-results').text(countBrowser)
-      })
-  }
-})
-
-/**
 *get headlessdev posts
 */
 


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [x] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
Remove any usage of the `/public-stats` endpoint as it being removed.