### PR TITLE
docs: adds direct downloads section [sc-00]

### DIFF
--- a/site/content/docs/cli/installation.md
+++ b/site/content/docs/cli/installation.md
@@ -101,7 +101,7 @@ npx checkly login
 If you cannot access the npm registry directly, you can also download the Checkly CLI via our CDN.
 
 - [MacOS / Darwin](https://cdn.checklyhq.com/downloads/checkly-cli/4.0.8/darwin/checkly.zip)
-- [Windows](https://cdn.checklyhq.com/downloads/checkly-cli/4.0.7/windows/checkly.zip)
+- [Windows](https://cdn.checklyhq.com/downloads/checkly-cli/4.0.8/windows/checkly.zip)
 
 The download is a zipped folder containing a full installation of [the boilerplate example project](https://github.com/checkly/checkly-cli/tree/main/examples/boilerplate-project).
 You will find the following files and folders:

--- a/site/content/docs/cli/installation.md
+++ b/site/content/docs/cli/installation.md
@@ -96,6 +96,25 @@ before hand or just sign up for a new account straight from the terminal.
 ```bash
 npx checkly login
 ```
+## Direct download
+
+If you cannot access the npm registry directly, you can also download the Checkly CLI via our CDN.
+
+- [MacOS / Darwin](https://cdn.checklyhq.com/downloads/checkly-cli/4.0.7/darwin/checkly.zip)
+- [Windows](https://cdn.checklyhq.com/downloads/checkly-cli/4.0.7/windows/checkly.zip)
+
+The download is a zipped folder containing a full installation of [the boilerplate example project](https://github.com/checkly/checkly-cli/tree/main/examples/boilerplate-project).
+You will find the following files and folders:
+- a `checkly.config.ts` file.
+- a `package.json` file including the necessary Typescript dependencies.
+- a `node_modules` directory with all dependencies pre-installed.
+- a `__checks__` folder with some example checks.
+
+{{< info >}}
+If you want to move the CLI and its constructs to a different, already existing Node.js project, just copy the full contents
+of the `node_modules` folder to your project and manually add a `checkly.config.ts` file.
+{{< /info >}}
+
 
 ## Authentication
 

--- a/site/content/docs/cli/installation.md
+++ b/site/content/docs/cli/installation.md
@@ -100,7 +100,7 @@ npx checkly login
 
 If you cannot access the npm registry directly, you can also download the Checkly CLI via our CDN.
 
-- [MacOS / Darwin](https://cdn.checklyhq.com/downloads/checkly-cli/4.0.7/darwin/checkly.zip)
+- [MacOS / Darwin](https://cdn.checklyhq.com/downloads/checkly-cli/4.0.8/darwin/checkly.zip)
 - [Windows](https://cdn.checklyhq.com/downloads/checkly-cli/4.0.7/windows/checkly.zip)
 
 The download is a zipped folder containing a full installation of [the boilerplate example project](https://github.com/checkly/checkly-cli/tree/main/examples/boilerplate-project).


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other


## Notes for the Reviewer
- adds section to CLI installation docs to directly download a CLI distribution

## Screenshots
![image](https://github.com/checkly/checklyhq.com/assets/3802923/1a78c793-92bc-44c4-9f1d-8cb86a539a7f)

