### PR TITLE
docs: make type of env vars more explicit

### DIFF
--- a/site/content/docs/cli/command-line-reference.md
+++ b/site/content/docs/cli/command-line-reference.md
@@ -94,7 +94,7 @@ Destroy all project's resources (checks, groups, alert channels, etc.) from your
 The `trigger` command is similar to the `test` command, but "triggers" checks already in your Checkly account. This works
 regardless of whether you created these checks via a `Project` with CLI constructs, via the UI or using Terraform.
 
-Because `trigger` does not rely on any `Project` or as-code representation of your checks, the invocation is slightly 
+Because `trigger` does not rely on any `Project` or as-code representation of your checks, the invocation is slightly
 different, as there are no files to reference for instance.
 
 ```bash
@@ -120,9 +120,9 @@ npx checkly trigger --record --test-session-name="Adhoc test run" --location=eu-
 - `--private-location <private location ID>`: Run checks against the specified private location.
 - `--record:` Record tests results in Checkly as a test session.
 - `--reporter` or `-r`: A list of custom reporters for the test output. Options are: list|dot|ci|github.
-- `--tags` or `-t`: Filter the checks to be triggered using a comma separated list of tags. Checks will only be run if 
-they contain all the specified tags. Multiple `--tags` flags can be passed, in which case checks will be run if they 
-match any of the `--tag`s filters, i.e. `--tags production,webapp --tags production,backend` will run checks with tags 
+- `--tags` or `-t`: Filter the checks to be triggered using a comma separated list of tags. Checks will only be run if
+they contain all the specified tags. Multiple `--tags` flags can be passed, in which case checks will be run if they
+match any of the `--tag`s filters, i.e. `--tags production,webapp --tags production,backend` will run checks with tags
 (production AND webapp) OR (staging AND backend).
 - `--test-session-name` A name to use when storing results in Checkly with `--record`.
 - `--timeout`: A fallback timeout (in seconds) to wait for checks to complete. Default 240.
@@ -150,13 +150,11 @@ List all available runtimes and their dependencies.
 
 ## `npx checkly env`
 
-The `checkly env` command is used to manage the environment variables of a Checkly account. You can list, add, remove, 
-update and export environment variables.
+Manage the global environment variables of a Checkly account. You can list, add, remove, update and export environment variables.
 
 ### `npx checkly env pull`
 
-The `checkly env pull` sub-command exports environment variables from your Checkly account to a local `.env` file or a 
-different file of your choice.
+Export global environment variables from your Checkly account to a local `.env` file or a different file of your choice.
 
 ```bash
 checkly env pull [FILENAME] [-f]
@@ -172,7 +170,7 @@ Pull all environment variables to the `.env` file and overwrite it if it already
 
 ### `npx checkly env ls`
 
-List global Checkly environment variables. This command does not list environment variables on group or check level.
+List global environment variables. This command does not list environment variables on group or check level.
 
 ```bash
 checkly env ls
@@ -180,7 +178,7 @@ checkly env ls
 
 ### `npx checkly env add`
 
-Adds an environment variable.
+Add a global environment variable.
 
 ```bash
 checkly env add [KEY] [VALUE] [-l]
@@ -192,7 +190,8 @@ checkly env add [KEY] [VALUE] [-l]
 
 
 ### `npx checkly env update`
-Updates a global environment variable.
+
+Update a global environment variable.
 
 ```bash
 checkly env update [KEY] [VALUE] [-l]

--- a/site/content/docs/cli/using-environment-variables.md
+++ b/site/content/docs/cli/using-environment-variables.md
@@ -20,7 +20,7 @@ remember:
 1. Use local environment variables to replace values in your constructs before `test` and `deploy` invocations.
 2. Local environment variables are not interpreted in code dependencies like `.spec.ts` files or setup and teardown scripts.
 
-Use local environment variables to inject or replace values in your `Check`, `AlertChannel` or other constructs at 
+Use local environment variables to inject or replace values in your `Check`, `AlertChannel` or other constructs at
 **build time** when the CLI compiles your constructs for testing and deploying.
 
 Here is an example of setting up an `SmsAlertChannel` where we pass in the actual phone number from a local environment
@@ -47,8 +47,8 @@ that SMS channel in your Checkly account.
 
 ## Remote Environment Variables
 
-Checkly also stores environment variables in your Checkly account. These can exist at the 
-[Account, Group or Check level](/docs/browser-checks/variables/). Here is what you need to remember:
+Checkly also stores environment variables in your Checkly account. These can exist at the
+[Global, Group or Check level](/docs/browser-checks/variables/). Here is what you need to remember:
 
 1. Use remote environment variables to dynamically inject or replace values during runtime of a check.
 2. Remote variables can be set and overridden when invoking the `test` command.
@@ -71,13 +71,13 @@ test('Check Home Page', async ({ page }) => {
 })
 ```
 
-You can now test this check and temporarily set the environment variable as follows. 
+You can now test this check and temporarily set the environment variable as follows.
 
 ```
 npx checkly test -e ENVIRONMENT_URL="https://staging.checklyhq.com"
 ```
 
-- Notice that we pass in the variable using the `-e` flag. This means it will be passed to the cloud environment and made 
+- Notice that we pass in the variable using the `-e` flag. This means it will be passed to the cloud environment and made
 available during runtime.
 - After deploying this check, the `ENVIRONMENT_URL` needs to be set at the Account, Group or Check level. If not set, the Check
 will use the fallback URL.
@@ -100,10 +100,11 @@ You can reference that file in the `test` as follows:
 npx checkly test --env-file="./.env"
 ```
 
-## Managing Environment Variables using the CLI
+## Managing Remote Environment Variables using the CLI
 
-You can manage your global environment variables with the CLI using the `checkly env` command. You can list, add, update, 
-remove and export your variables. Exporting is very powerful, as you can 
+Manage your remote environment variables with the CLI using the `checkly env` command. You can list, add, update, remove and export your global variables.
+
+Exporting is very powerful, as you can:
 
 1. Pull in the variables from your account with `npx checkly env pull` to a `.env` file.
 2. Reference that file in your `test` command with `npx checkly test --env-file="./.env"`
@@ -118,5 +119,5 @@ For storing and securing environment variables, we advise the following:
 1. Store local environment variables in your shell or in `.env` files that are not committed to your git repo. Add those
 files to your `.gitignore` file.
 2. In a CI context, e.g. GitHub Actions, store sensitive variables as secrets. Almost all CI providers have such a feature.
-3. For remote variables, store sensitive secrets at the Account level and click the lock icon so Read Only users cannot view them. 
+3. For remote variables, store sensitive secrets at the Account level and click the lock icon so Read Only users cannot view them.
 All variables are stored encrypted at rest and in transfer.


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Notes for the Reviewer

Nothing major to see here. Just enforced the naming convention around global variables.

