### PR TITLE
feat: add warning to slack integration about free account limits

### DIFF
--- a/site/content/docs/integrations/slack.md
+++ b/site/content/docs/integrations/slack.md
@@ -19,6 +19,9 @@ You have the option to customize the default channel you've set in Slack by sett
 
 By customizing the channel name, alerting options & checks for that alert channel, you can use a single Incoming WebHook URL for multiple scenarios.
 
+>[!WARNING]
+> If you’re using a free Slack workspace, be aware of [message limits](https://slack.com/help/articles/115002422943-Usage-limits-for-free-workspaces). Exceeding these limits may prevent new alerts from being delivered.
+
 ## Example Failed Slack Alert
 
 We provide a lot of information in the initial Slack message including links to the check and check result as well as the whole response body.


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [X] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [X] Code is linted (`npm run lint`)

## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

## New Dependency Submission
Free slack accounts have limits on messages. These can cause alerts not to be delivered.

This adds a warning about this fact to the slack integration docs.

## Screenshots

![Bildschirmfoto 2024-12-20 um 12 25 42](https://github.com/user-attachments/assets/d9126d95-91ce-48b6-b475-c7803a6681fc)


