### PR TITLE
Fix learn mega heading css

### DIFF
--- a/site/layouts/learn/learn-home.html
+++ b/site/layouts/learn/learn-home.html
@@ -2,7 +2,7 @@
 <div class="d-flex container-fluid learn py-5">
   <div class="learn-page">
     <article>
-      <h1 class="display-3 w-75">
+      <h1 class="mega-heading">
         {{ if .Params.displayTitle}}
         {{.Params.displayTitle}}
         {{else}}

--- a/src/scss/_learn.scss
+++ b/src/scss/_learn.scss
@@ -532,6 +532,13 @@
     }
   }
 
+  .mega-heading {
+    font-size: 3.65rem;
+    font-weight: 600;
+    line-height: 1.6;
+    width: 75%;
+  }
+
   @include media-breakpoint-down(md) {
     .learn-page {
       padding: .5rem;
@@ -610,6 +617,11 @@
           }
         }
       }
+    }
+
+    .mega-heading {
+      width: 100%;
+      font-size: 2rem;
     }
   }
 


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Notes for the Reviewer

The PR fixes the mega heading on `/learn`.

Before:

<img width="1433" alt="grafik" src="https://github.com/user-attachments/assets/764bbe5b-a9be-4153-a96c-7220a711fa13" />

After:

<img width="1424" alt="grafik" src="https://github.com/user-attachments/assets/354f9815-4388-4eed-b07a-9bb56036f6d8" />
