### PR TITLE
docs: reflect API change — regions now map to IPv6 address arrays

### DIFF
--- a/site/content/docs/monitoring/allowlisting.md
+++ b/site/content/docs/monitoring/allowlisting.md
@@ -42,7 +42,7 @@ curl https://api.checklyhq.com/v1/static-ips.txt
 curl https://api.checklyhq.com/v1/static-ipv6s
 ```
 
-5. A JSON object with regions as keys and an IPv6 as value.
+5. A JSON object with regions as keys and arrays of all IPv6s of that region as the value
 
 ```bash
 curl https://api.checklyhq.com/v1/static-ipv6s-by-region


### PR DESCRIPTION
The allow-listing guide previously stated that each region key in the JSON object held a single IPv6 address.
Because the API now returns multiple addresses per region, step 5 has been updated to specify that each region key maps to an array of all IPv6s for that region.

Ref: https://github.com/checkly/checkly-backend/pull/6587

## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->

## Screenshots
<!-- Screenshot of any visual changes -->
