### PR TITLE
add mention of TCP dumps in dev docs

### DIFF
--- a/site/content/docs/monitoring/check-results.md
+++ b/site/content/docs/monitoring/check-results.md
@@ -132,6 +132,8 @@ These include:
 
     e. Download
 
+5. Network diagnostics: For failed checks, a downloadable TCP dump (.pcap) file is available to help you troubleshoot low-level network issues like dropped packets or failed handshakes. Check your [plan type](https://www.checklyhq.com/pricing/) for availability.
+
 ## Heartbeat monitor results
 
 Heartbeat monitor results show information about the ping request, like when it was recieved and its source.


### PR DESCRIPTION
Add mention of TCP dumps to our dev docs.

Very minimal for now - Once we have MTR / Trace routes in place (which will be shipped shortly), we'll be publishing a dedicated "Diagnosing Network Issues" page: https://www.notion.so/checkly/Network-Diagnostics-Dev-Docs-26bec050b06e807c8c8bcf0e14204aac (Internal)
