### PR TITLE
Correct command syntax for pw-test

### DIFF
--- a/site/content/docs/playwright-checks/_index.md
+++ b/site/content/docs/playwright-checks/_index.md
@@ -54,7 +54,7 @@ Run your Playwright test suite using `pw-test`.
 
 `pw-test` accepts both Checkly and Playwright command line arguments using the following syntax:
 
-`npx checkly pwtest --checky-flag -- --playwright-flag`. Use `--` to seperate Checkly and Playwright flags.
+`npx checkly pw-test --checkly-flag -- --playwright-flag`. Use `--` to seperate Checkly and Playwright flags.
 
 The CLI command will then return a link to results, traces and more details:
 


### PR DESCRIPTION
Fix typo in CLI command for pw-test usage.

## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [X] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [X] Code is linted (`npm run lint`)